### PR TITLE
kubernetes endpoint to kubernetes-external service

### DIFF
--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -17,7 +17,7 @@ set -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO: Should subcharts also be exposed directly? If not, this list needs to be kept up-to-date
-charts=( wire-server fake-aws databases-ephemeral redis-ephemeral metallb nginx-lb-ingress demo-smtp )
+charts=( wire-server fake-aws databases-ephemeral redis-ephemeral metallb nginx-lb-ingress demo-smtp cassandra-external minio-external elasticsearch-external )
 
 # install s3 plugin
 # At the time of writing, version 0.7.0 was installed.

--- a/charts/cassandra-external/Chart.yaml
+++ b/charts/cassandra-external/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Refer to cassandra IPs located outside kubernetes by specifying IPs manually
+name: cassandra-external
+version: 0.1.0

--- a/charts/cassandra-external/templates/endpoint.yaml
+++ b/charts/cassandra-external/templates/endpoint.yaml
@@ -1,0 +1,35 @@
+# create a headless service (thus creating dns name "cassandra-external")
+# and a custom endpoint (thus forwarding traffic when resolving DNS to custom IPs)
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "cassandra-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None # create a headless service, we want no extra load balancing for cassandra
+  ports:
+  - name: cql
+    port: {{ .Values.portCql }}
+    targetPort: {{ .Values.portCql }}
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "cassandra-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets:
+  - addresses:
+      {{- range .Values.IPs }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      - port: {{ .Values.portCql }}

--- a/charts/cassandra-external/templates/helpers.tpl
+++ b/charts/cassandra-external/templates/helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "cassandra-external.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cassandra-external.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/cassandra-external/values.yaml
+++ b/charts/cassandra-external/values.yaml
@@ -1,0 +1,6 @@
+portCql: 9042
+
+## Configure this helm chart with:
+# IPs:
+#   - 1.2.3.4
+#   - 5.6.7.8

--- a/charts/elasticsearch-external/Chart.yaml
+++ b/charts/elasticsearch-external/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Refer to elasticsearch IPs located outside kubernetes by specifying IPs manually
+name: elasticsearch-external
+version: 0.1.0

--- a/charts/elasticsearch-external/templates/endpoint.yaml
+++ b/charts/elasticsearch-external/templates/endpoint.yaml
@@ -1,0 +1,35 @@
+# create a headless clusterIP service to create dns name "elasticsearch-external"
+# and a custom endpoint, thus forwarding traffic when resolving DNS to custom IPs
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "elasticsearch-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None # headless service
+  ports:
+  - name: http
+    port: {{ .Values.portHttp }}
+    targetPort: {{ .Values.portHttp }}
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "elasticsearch-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets:
+  - addresses:
+      {{- range .Values.IPs }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      - port: {{ .Values.portHttp }}

--- a/charts/elasticsearch-external/templates/helpers.tpl
+++ b/charts/elasticsearch-external/templates/helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "elasticsearch-external.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch-external.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/elasticsearch-external/values.yaml
+++ b/charts/elasticsearch-external/values.yaml
@@ -1,0 +1,6 @@
+portHttp: 9200
+
+## Configure this helm chart with:
+# IPs:
+#   - 1.2.3.4
+#   - 5.6.7.8

--- a/charts/minio-external/Chart.yaml
+++ b/charts/minio-external/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Refer to minio IPs located outside kubernetes by specifying IPs manually
+name: minio-external
+version: 0.1.0

--- a/charts/minio-external/templates/endpoint.yaml
+++ b/charts/minio-external/templates/endpoint.yaml
@@ -1,0 +1,35 @@
+# create a headless service (thus creating dns name "minio-external")
+# and a custom endpoint (thus forwarding traffic when resolving DNS to custom IPs)
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "minio-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None # create a headless service, we want no extra load balancing for minio
+  ports:
+  - name: minio
+    port: {{ .Values.portHttp }}
+    targetPort: {{ .Values.portHttp }}
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "minio-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets:
+  - addresses:
+      {{- range .Values.IPs }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      - port: {{ .Values.portHttp }}

--- a/charts/minio-external/templates/helpers.tpl
+++ b/charts/minio-external/templates/helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "minio-external.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "minio-external.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/minio-external/values.yaml
+++ b/charts/minio-external/values.yaml
@@ -1,0 +1,6 @@
+portHttp: 9000
+
+## Configure this helm chart with:
+# IPs:
+#   - 1.2.3.4
+#   - 5.6.7.8


### PR DESCRIPTION
Use DNS resolving via endpoints inside kubernetes to talk to services outside kubernetes. `brig` can thus talk to the DNS name `cassandra-external` which will resolve to the IPs manually specified in the `cassandra-external`'s values file (which are assumed to be managed outside kubernetes). 
* cassandra
* elasticsearch
* minio (S3)