### PR TITLE
Fix external endpoints

### DIFF
--- a/charts/cassandra-external/Chart.yaml
+++ b/charts/cassandra-external/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Refer to cassandra IPs located outside kubernetes by specifying IPs manually
 name: cassandra-external
-version: 0.1.0
+version: 0.1.1

--- a/charts/cassandra-external/templates/endpoint.yaml
+++ b/charts/cassandra-external/templates/endpoint.yaml
@@ -32,5 +32,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
+      # port and name in the endpoint must match port and name in the service
+      # see also https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html
       - name: cql
         port: {{ .Values.portCql }}

--- a/charts/cassandra-external/templates/endpoint.yaml
+++ b/charts/cassandra-external/templates/endpoint.yaml
@@ -32,4 +32,5 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - port: {{ .Values.portCql }}
+      - name: cql
+        port: {{ .Values.portCql }}

--- a/charts/minio-external/Chart.yaml
+++ b/charts/minio-external/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Refer to minio IPs located outside kubernetes by specifying IPs manually
 name: minio-external
-version: 0.1.0
+version: 0.1.1

--- a/charts/minio-external/templates/endpoint.yaml
+++ b/charts/minio-external/templates/endpoint.yaml
@@ -32,5 +32,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
+      # port and name in the endpoint must match port and name in the service
+      # see also https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html
       - name: minio
         port: {{ .Values.portHttp }}

--- a/charts/minio-external/templates/endpoint.yaml
+++ b/charts/minio-external/templates/endpoint.yaml
@@ -32,4 +32,5 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - port: {{ .Values.portHttp }}
+      - name: minio
+        port: {{ .Values.portHttp }}

--- a/charts/nginx-lb-ingress/Chart.yaml
+++ b/charts/nginx-lb-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for ingresses (using nginx) on Kubernetes
 name: nginx-lb-ingress
-version: 0.1.1
+version: 0.1.2

--- a/charts/nginx-lb-ingress/requirements.yaml
+++ b/charts/nginx-lb-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 0.28.3
+  version: 1.1.5
   repository: https://kubernetes-charts.storage.googleapis.com

--- a/charts/nginx-lb-ingress/templates/ingress.yaml
+++ b/charts/nginx-lb-ingress/templates/ingress.yaml
@@ -49,7 +49,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: fake-aws-s3
+              serviceName: {{ .Values.service.s3.serviceName }}
               servicePort: {{ .Values.service.s3.externalPort }}
 {{- if .Values.teamSettings.enabled }}
     - host: {{ .Values.config.dns.teamSettings }}

--- a/charts/nginx-lb-ingress/templates/service.yaml
+++ b/charts/nginx-lb-ingress/templates/service.yaml
@@ -33,6 +33,7 @@ spec:
       targetPort: 8080
   selector:
     wireService: webapp
+{{- if not .Values.service.s3.externallyCreated }}
 ---
 apiVersion: v1
 kind: Service
@@ -44,7 +45,8 @@ spec:
     - port: {{ .Values.service.s3.externalPort }}
       targetPort: 9000
   selector:
-    wireService: fake-aws-s3
+    wireService: {{ .Values.service.s3.serviceName }}
+{{- end }}
 {{- if .Values.teamSettings.enabled }}
 ---
 apiVersion: v1
@@ -58,4 +60,18 @@ spec:
       targetPort: 8080
   selector:
     wireService: team-settings
+{{- end }}
+{{- if .Values.accountPages.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: account-pages-http
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.accountPages.externalPort }}
+      targetPort: 8080
+  selector:
+    wireService: account-pages
 {{- end }}

--- a/charts/nginx-lb-ingress/values.yaml
+++ b/charts/nginx-lb-ingress/values.yaml
@@ -34,6 +34,8 @@ service:
     externalPort: 8080
   s3:
     externalPort: 9000
+    serviceName: fake-aws-s3
+    externallyCreated: false # See note below
   teamSettings:
     externalPort: 8080
   accountPages:
@@ -59,3 +61,12 @@ service:
 #         -----BEGIN PRIVATE KEY-----
 #         -----END PRIVATE KEY-----
 #
+# For Services:
+# service:
+#   s3:
+#     externallyCreated: true
+#     ^ externallyCreated might be useful if S3 access is provided by
+#       an external service such as `minio-external`: in such cases
+#       we do not want to create yet another service here but rather
+#       use that service instead in the ingress
+#     serviceName: minio-external


### PR DESCRIPTION
Relevant changes:
 * Fixes external endpoints to be reachable from the nginx-ingress
 * Upgrades nginx-ingress to the latest version
 * Allows using an external service in the S3 part of the nginx-ingress (useful if minio is outside of k8s)
 * Added a missing ingress for team settings

The most important bit is https://github.com/wireapp/wire-server-deploy/commit/8aef810076bbed95370a3573db966edd61ff7f7c - particularly the fact that the name of the ports in the `Endpoints` must match the `Service` in order for this to work - I am not sure how/why this worked before: it worked "internally" (i.e., brig was able to reach an external cassandra) but the nginx-ingress was not, kept returning a 503

Relevant references:

https://appscode.com/products/voyager/7.1.1/guides/ingress/http/external-svc/#using-external-ip
https://github.com/kubernetes/kubernetes/issues/8631#issuecomment-104760910
https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html - _The port and name definition must match the port and name value in the service_

The [publishNotReadyAddresses](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/) may be interesting too for peer discovery purposes.

