### PR TITLE
Skip buggy version of nginx-ingress

### DIFF
--- a/charts/nginx-lb-ingress/Chart.yaml
+++ b/charts/nginx-lb-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for ingresses (using nginx) on Kubernetes
 name: nginx-lb-ingress
-version: 0.1.2
+version: 0.1.3

--- a/charts/nginx-lb-ingress/requirements.yaml
+++ b/charts/nginx-lb-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 1.1.5
+  version: 1.3.0
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Sadly that version of the ingress contained a problematic bug that I ran into on one of our bare metal installations, namely [this bug](https://github.com/helm/charts/pull/7933#issuecomment-439711350).

Fortunately downtime was acceptable there so a force recreation was not particularly problematic.