### PR TITLE
Add some env config options

### DIFF
--- a/charts/demo-smtp/Chart.yaml
+++ b/charts/demo-smtp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A demo helm chart to send emails. Not production ready.
 name: demo-smtp
-version: 0.1.0
+version: 0.1.1

--- a/charts/demo-smtp/templates/deployment.yaml
+++ b/charts/demo-smtp/templates/deployment.yaml
@@ -23,8 +23,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
-            - name: RELAY_NETWORKS
-              value: "{{ .Values.config.relayNetworks }}"
+        {{- range $key, $val := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ $val }}
+        {{- end }}
           ports:
             - name: smtp
               containerPort: 25

--- a/charts/demo-smtp/templates/deployment.yaml
+++ b/charts/demo-smtp/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: RELAY_NETWORKS
+              value: "{{ .Values.config.relayNetworks }}"
           ports:
             - name: smtp
               containerPort: 25

--- a/charts/demo-smtp/values.yaml
+++ b/charts/demo-smtp/values.yaml
@@ -15,10 +15,12 @@ resources:
    cpu: 100m
    memory: 128Mi
 
-# Some relevant config options, check
+# Some relevant environment options can be
+# passed to the SMTP docker image, check
 # https://hub.docker.com/r/namshi/smtp/
 # for more details
-#
-# config:
-#   relayNetworks:
+envVars:
+# E.g.
+# envVars:
+#   RELAY_NETWORKS: ":x.y.z.w/16"
 #

--- a/charts/demo-smtp/values.yaml
+++ b/charts/demo-smtp/values.yaml
@@ -14,3 +14,11 @@ resources:
   requests:
    cpu: 100m
    memory: 128Mi
+
+# Some relevant config options, check
+# https://hub.docker.com/r/namshi/smtp/
+# for more details
+#
+# config:
+#   relayNetworks:
+#


### PR DESCRIPTION
If `exim` and the STMP relay are not in the same network, you will end up seeing errors like _relay not permitted_; this allows us to tell exim which networks should be taken into account as relays