### PR TITLE
Add a docs/index.md file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Wire backend deployment
+
+This documentation is work in progress.
+
+* [Configuration](configuration.md)
+* [Referencing helm charts from this repo](pending.md)


### PR DESCRIPTION
Github Pages doesn't generate an index automatically (or it does but requires configuration; an explicit index might still be better)