### PR TITLE
Versioning

### DIFF
--- a/bin/set-version.sh
+++ b/bin/set-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+USAGE="Write version to chart and subcharts (if any). Usage: $0 <chartname> <semantic version>"
+chart=${1:?$USAGE}
+version=${2:?$USAGE}
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CHART_DIR="$( cd "$SCRIPT_DIR/../charts" && pwd )"
+tempfile=$(mktemp)
+
+# (sed usage should be portable for both GNU sed and BSD (Mac OS) sed)
+
+function update_chart(){
+    chart_file=$1
+    sed -e "s/version: .*/version: $target_version/g" "$chart_file" > "$tempfile" && mv "$tempfile" "$chart_file"
+}
+
+function write_versions() {
+    target_version=$1
+
+    # update chart version
+    update_chart Chart.yaml
+
+    # update all dependencies, if any
+    if [ -a requirements.yaml ]; then
+        sed -e "s/  version: \".*\"/  version: \"$target_version\"/g" requirements.yaml > "$tempfile" && mv "$tempfile" requirements.yaml
+        deps=( $(helm dependency list | grep -v NAME | awk '{print $1}') )
+        for dep in "${deps[@]}"; do
+            if [ -d "$CHART_DIR/$dep" ]; then
+                (cd "$CHART_DIR/$dep" && write_versions "$target_version")
+            fi
+        done
+    fi
+}
+
+cd "$CHART_DIR/$chart" && write_versions "$version"


### PR DESCRIPTION
Example usage: `./bin/set-version.sh wire-server 0.0.1-test`

```patch
diff --git a/charts/account-pages/Chart.yaml b/charts/account-pages/Chart.yaml
index b751b84..5f287e8 100644
--- a/charts/account-pages/Chart.yaml
+++ b/charts/account-pages/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire account pages in Kubernetes
 name: account-pages
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/brig/Chart.yaml b/charts/brig/Chart.yaml
index 1a96aef..6fe64dd 100644
--- a/charts/brig/Chart.yaml
+++ b/charts/brig/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Brig (part of Wire Server) - User management
 name: brig
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/cannon/Chart.yaml b/charts/cannon/Chart.yaml
index 5662d52..963d171 100644
--- a/charts/cannon/Chart.yaml
+++ b/charts/cannon/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for cannon in Kubernetes
 name: cannon
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/cargohold/Chart.yaml b/charts/cargohold/Chart.yaml
index 5ff4125..198aa7b 100644
--- a/charts/cargohold/Chart.yaml
+++ b/charts/cargohold/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Cargohold (part of Wire Server) - Asset storage
 name: cargohold
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/cassandra-migrations/Chart.yaml b/charts/cassandra-migrations/Chart.yaml
index 6081bde..563cb96 100644
--- a/charts/cassandra-migrations/Chart.yaml
+++ b/charts/cassandra-migrations/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: cassandra database schema migration for gundeck,brig,galley,spar
 name: cassandra-migrations
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/elasticsearch-index/Chart.yaml b/charts/elasticsearch-index/Chart.yaml
index 9631dec..0403da1 100644
--- a/charts/elasticsearch-index/Chart.yaml
+++ b/charts/elasticsearch-index/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Elasticsearch index for brig
 name: elasticsearch-index
-version: 0.1.1
+version: 0.0.1-test1
diff --git a/charts/galley/Chart.yaml b/charts/galley/Chart.yaml
index cdad302..6f8661e 100644
--- a/charts/galley/Chart.yaml
+++ b/charts/galley/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Galley (part of Wire Server) - Conversations
 name: galley
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/gundeck/Chart.yaml b/charts/gundeck/Chart.yaml
index 19df96d..edfc437 100644
--- a/charts/gundeck/Chart.yaml
+++ b/charts/gundeck/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Gundeck (part of Wire Server) - Push Notification Hub Service
 name: gundeck
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/nginz/Chart.yaml b/charts/nginz/Chart.yaml
index 75df7f7..bf9094c 100644
--- a/charts/nginz/Chart.yaml
+++ b/charts/nginz/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for nginz in Kubernetes
 name: nginz
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/proxy/Chart.yaml b/charts/proxy/Chart.yaml
index 5a0eb7c..f5165c5 100644
--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Proxy (part of Wire Server) - 3rd party proxy service
 name: proxy
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/spar/Chart.yaml b/charts/spar/Chart.yaml
index 4c41e72..4f7ca88 100644
--- a/charts/spar/Chart.yaml
+++ b/charts/spar/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Spar (part of Wire Server) - SSO Service
 name: spar
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/team-settings/Chart.yaml b/charts/team-settings/Chart.yaml
index 9161f5f..cc9e8fb 100644
--- a/charts/team-settings/Chart.yaml
+++ b/charts/team-settings/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire team-settings in Kubernetes
 name: team-settings
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/webapp/Chart.yaml b/charts/webapp/Chart.yaml
index ad0b013..d6a5c09 100644
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/wire-server/Chart.yaml b/charts/wire-server/Chart.yaml
index 51e043e..662c824 100644
--- a/charts/wire-server/Chart.yaml
+++ b/charts/wire-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for wire-server https://github.com/wireapp/wire-server
 name: wire-server
-version: 0.1.2
+version: 0.0.1-test1
diff --git a/charts/wire-server/requirements.yaml b/charts/wire-server/requirements.yaml
index c9fed2c..1883f01 100644
--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -3,12 +3,12 @@ dependencies:
 ## wire-servers/database cassandra-migrations
 ########################
 - name: cassandra-migrations
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../cassandra-migrations"
   tags:
     - cassandra-migrations
 - name: elasticsearch-index
-  version: "0.1.1"
+  version: "0.0.1-test1"
   repository: "file://../elasticsearch-index"
   tags:
     - elasticsearch-index
@@ -16,75 +16,75 @@ dependencies:
 ## wire-servers/services
 ########################
 - name: cannon
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../cannon"
   tags:
     - cannon
     - haskellServices
     - services
 - name: proxy
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../proxy"
   tags:
     - proxy
     - haskellServices
     - services
 - name: cargohold
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../cargohold"
   tags:
     - cargohold
     - haskellServices
     - services
 - name: gundeck
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../gundeck"
   tags:
     - gundeck
     - haskellServices
     - services
 - name: spar
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../spar"
   tags:
     - spar
     - haskellServices
     - services
 - name: galley
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../galley"
   tags:
     - galley
     - haskellServices
     - services
 - name: brig
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../brig"
   tags:
     - brig
     - haskellServices
     - services
 - name: nginz
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../nginz"
   tags:
     - nginz
     - services
 - name: webapp
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../webapp"
   tags:
     - web
     - webapp
 - name: team-settings
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../team-settings"
   tags:
     - web
     - team-settings
     - private
 - name: account-pages
-  version: "0.1.2"
+  version: "0.0.1-test1"
   repository: "file://../account-pages"
   tags:
     - web
```