### PR TITLE
Allow defining TURN config as a list of URLs

### DIFF
--- a/charts/account-pages/Chart.yaml
+++ b/charts/account-pages/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire account pages in Kubernetes
 name: account-pages
-version: 0.1.2
+version: 0.1.3

--- a/charts/brig/Chart.yaml
+++ b/charts/brig/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Brig (part of Wire Server) - User management
 name: brig
-version: 0.1.2
+version: 0.1.3

--- a/charts/brig/templates/conf/_turn-servers-v2.txt.tpl
+++ b/charts/brig/templates/conf/_turn-servers-v2.txt.tpl
@@ -1,0 +1,4 @@
+{{ define "turn-servers-v2.txt" }}
+{{ range .Values.turnStatic.v2 }}{{ . }}
+{{ end -}}
+{{ end }}

--- a/charts/brig/templates/conf/_turn-servers.txt.tpl
+++ b/charts/brig/templates/conf/_turn-servers.txt.tpl
@@ -1,0 +1,4 @@
+{{ define "turn-servers.txt" }}
+{{ range .Values.turnStatic.v1 }}{{ . }}
+{{ end -}}
+{{ end }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -31,33 +31,12 @@ spec:
         - name: "brig-config"
           configMap:
             name: "brig"
+        - name: "turn-servers"
+          configMap:
+            name: "turn"
         - name: "brig-secrets"
           secret:
             secretName: "brig"
-        - name: "turn-servers"
-          emptyDir: {}
-      initContainers:
-        # TODO: Proper TURN/calling config;
-        # this just creates a file to allow brig to start, but
-        # audio/video/TURN will not work
-        - name: fake-turn
-          image: alpine:3.6
-          command:
-          - sh
-          - -c
-          - echo -e "{{- range .Values.turnStatic.v1 }}{{ . }}\n{{- end }}" | sed '$d' > /etc/wire/brig/turn/turn-servers.txt
-          volumeMounts:
-          - name: turn-servers
-            mountPath: "/etc/wire/brig/turn"
-        - name: fake-turn-v2
-          image: alpine:3.6
-          command:
-          - sh
-          - -c
-          - echo -e "{{- range .Values.turnStatic.v2 }}{{ . }}\n{{- end }}" | sed '$d' > /etc/wire/brig/turn/turn-servers-v2.txt
-          volumeMounts:
-          - name: turn-servers
-            mountPath: "/etc/wire/brig/turn"
       containers:
         - name: brig
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           command:
           - sh
           - -c
-          - echo turn:127.0.0.1:3478 >> /etc/wire/brig/turn/turn-servers.txt
+          - echo -e "{{- range .Values.turnStatic.v1 }}{{ . }}\n{{- end }}" | sed '$d' > /etc/wire/brig/turn/turn-servers.txt
           volumeMounts:
           - name: turn-servers
             mountPath: "/etc/wire/brig/turn"
@@ -54,7 +54,7 @@ spec:
           command:
           - sh
           - -c
-          - echo turn:localhost:3478 >> /etc/wire/brig/turn/turn-servers-v2.txt
+          - echo -e "{{- range .Values.turnStatic.v2 }}{{ . }}\n{{- end }}" | sed '$d' > /etc/wire/brig/turn/turn-servers-v2.txt
           volumeMounts:
           - name: turn-servers
             mountPath: "/etc/wire/brig/turn"

--- a/charts/brig/templates/turnconfigmap.yaml
+++ b/charts/brig/templates/turnconfigmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "turn"
+  labels:
+    wireService: brig
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  turn-servers.txt: |2
+{{- include "turn-servers.txt" . | indent 4 }}
+  turn-servers-v2.txt: |2
+{{- include "turn-servers-v2.txt" . | indent 4 }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -68,6 +68,13 @@ config:
   smtp:
     passwordFile: "/etc/wire/brig/secrets/smtp-password.txt"
 
+turnStatic:
+  v1:
+    - "turn:localhost:3478"
+  v2:
+    - "turn:localhost:3478"
+    - "turn:localhost:3478?transport=tcp"
+
 ## The following has to be provided to deploy this chart:
 
 #config:

--- a/charts/cannon/Chart.yaml
+++ b/charts/cannon/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for cannon in Kubernetes
 name: cannon
-version: 0.1.2
+version: 0.1.3

--- a/charts/cargohold/Chart.yaml
+++ b/charts/cargohold/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Cargohold (part of Wire Server) - Asset storage
 name: cargohold
-version: 0.1.2
+version: 0.1.3

--- a/charts/cassandra-migrations/Chart.yaml
+++ b/charts/cassandra-migrations/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: cassandra database schema migration for gundeck,brig,galley,spar
 name: cassandra-migrations
-version: 0.1.2
+version: 0.1.3

--- a/charts/elasticsearch-index/Chart.yaml
+++ b/charts/elasticsearch-index/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Elasticsearch index for brig
 name: elasticsearch-index
-version: 0.1.1
+version: 0.1.3

--- a/charts/galley/Chart.yaml
+++ b/charts/galley/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Galley (part of Wire Server) - Conversations
 name: galley
-version: 0.1.2
+version: 0.1.3

--- a/charts/gundeck/Chart.yaml
+++ b/charts/gundeck/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Gundeck (part of Wire Server) - Push Notification Hub Service
 name: gundeck
-version: 0.1.2
+version: 0.1.3

--- a/charts/nginz/Chart.yaml
+++ b/charts/nginz/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for nginz in Kubernetes
 name: nginz
-version: 0.1.2
+version: 0.1.3

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Proxy (part of Wire Server) - 3rd party proxy service
 name: proxy
-version: 0.1.2
+version: 0.1.3

--- a/charts/spar/Chart.yaml
+++ b/charts/spar/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Spar (part of Wire Server) - SSO Service
 name: spar
-version: 0.1.2
+version: 0.1.3

--- a/charts/team-settings/Chart.yaml
+++ b/charts/team-settings/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire team-settings in Kubernetes
 name: team-settings
-version: 0.1.2
+version: 0.1.3

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.1.2
+version: 0.1.3

--- a/charts/wire-server/Chart.yaml
+++ b/charts/wire-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for wire-server https://github.com/wireapp/wire-server
 name: wire-server
-version: 0.1.2
+version: 0.1.3

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -58,7 +58,7 @@ dependencies:
     - haskellServices
     - services
 - name: brig
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../brig"
   tags:
     - brig

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -3,12 +3,12 @@ dependencies:
 ## wire-servers/database cassandra-migrations
 ########################
 - name: cassandra-migrations
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../cassandra-migrations"
   tags:
     - cassandra-migrations
 - name: elasticsearch-index
-  version: "0.1.1"
+  version: "0.1.3"
   repository: "file://../elasticsearch-index"
   tags:
     - elasticsearch-index
@@ -16,42 +16,42 @@ dependencies:
 ## wire-servers/services
 ########################
 - name: cannon
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../cannon"
   tags:
     - cannon
     - haskellServices
     - services
 - name: proxy
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../proxy"
   tags:
     - proxy
     - haskellServices
     - services
 - name: cargohold
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../cargohold"
   tags:
     - cargohold
     - haskellServices
     - services
 - name: gundeck
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../gundeck"
   tags:
     - gundeck
     - haskellServices
     - services
 - name: spar
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../spar"
   tags:
     - spar
     - haskellServices
     - services
 - name: galley
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../galley"
   tags:
     - galley
@@ -65,26 +65,26 @@ dependencies:
     - haskellServices
     - services
 - name: nginz
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../nginz"
   tags:
     - nginz
     - services
 - name: webapp
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../webapp"
   tags:
     - web
     - webapp
 - name: team-settings
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../team-settings"
   tags:
     - web
     - team-settings
     - private
 - name: account-pages
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "file://../account-pages"
   tags:
     - web


### PR DESCRIPTION
This is pretty sufficient in many installations with static IP addresses; a more dynamic strategy can still be added later, as suggested [here](https://github.com/wireapp/wire-server-deploy/blob/master/README.md#status)