### PR TITLE
Minimal setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ demo-values.yaml
 requirements.lock
 values/*/demo-values.override.yaml
 values/*/demo-secrets.override.yaml
+.DS_Store

--- a/bin/demo-setup.sh
+++ b/bin/demo-setup.sh
@@ -3,25 +3,39 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
 display_usage() {
-    echo "Usage: setup -o"
-    echo "  -o   use this option if you want to override default values/secrets (i.e., looks for secrets.override.yaml and values.override.yaml)"
+    echo "Usage: setup -o -b -s"
+    echo "  -o   (--override--values) default values/secrets (i.e., looks for secrets.override.yaml and values.override.yaml)"
+    echo "  -b   (--no-load-balancer) use this if you do not want to install a load balancer on the cluster (useful for cloud installations that have their own LB's)"
+    echo "  -s   (--skip-dependency-update) do not update any helm chart dependencies (can be useful for reruns)"
     exit 1
 }
 
 secretsfilename="demo-secrets.example.yaml"
 valuesfilename="demo-values.example.yaml"
+installloadbalancer=true
+updatedependencies=true
 
-while getopts ":o" opt; do
+while getopts ":obs" opt; do
   case $opt in
     o)
       secretsfilename="demo-secrets.override.yaml"
       valuesfilename="demo-values.override.yaml"
       ;;
+    b)
+      installloadbalancer=false
+      ;;
+    s)
+      updatedependencies=false
+      ;;
   esac
 done
 
-echo $secretsfilename
-echo $valuesfilename
+echo "######################################################"
+echo "Secrets: $secretsfilename"
+echo "Values: $valuesfilename"
+echo "Install loadbalancer on the cluster: $installloadbalancer"
+echo "Update dependencies: $updatedependencies"
+echo "######################################################"
 
 NAMESPACE=${NAMESPACE:-demo}
 
@@ -36,19 +50,23 @@ phase_2_charts_main=( wire-server )
 phase_3_charts_ingress=( nginx-lb-ingress )
 all_charts=( "${phase_0_charts_metallb[@]}" "${phase_1_charts_pre[@]}" "${phase_2_charts_main[@]}" "${phase_3_charts_ingress[@]}")
 
-# remove previous versions of helm charts, if any
-find "$DIR/charts" | grep ".tgz" | xargs -n 1 rm
+if [ "$updatedependencies" == true ] ; then
+    # remove previous versions of helm charts, if any
+    find "$DIR/charts" | grep ".tgz" | xargs -n 1 rm
 
-# download/refresh dependencies, if any
-helm repo add cos https://centerforopenscience.github.io/helm-charts/
-for chart in "${all_charts[@]}"; do
-    source "$DIR/bin/update.sh" "${chart}"
-done
+    # download/refresh dependencies, if any
+    helm repo add cos https://centerforopenscience.github.io/helm-charts/
+    for chart in "${all_charts[@]}"; do
+        source "$DIR/bin/update.sh" "${chart}"
+    done
+fi
 
-# Note that we should have a single metal lb in the whole cluster!
-helm upgrade --install --namespace metallb-system metallb \
-    "${DIR}/charts/metallb" -f "${DIR}/values/metallb/${valuesfilename}" \
-    --wait --timeout 1800
+if [ "$installloadbalancer" == true ] ; then
+    # Note that we should have a single metal lb in the whole cluster!
+    helm upgrade --install --namespace metallb-system metallb \
+        "${DIR}/charts/metallb" -f "${DIR}/values/metallb/${valuesfilename}" \
+        --wait --timeout 1800
+fi
 
 for chart in "${phase_1_charts_pre[@]}"; do
     valuesfile="${DIR}/values/${chart}/${valuesfilename}"

--- a/charts/cassandra-ephemeral/Chart.yaml
+++ b/charts/cassandra-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Wrapper chart for incubator/cassandra with custom settings to be used as non-persistent cassandra during tests
 name: cassandra-ephemeral
-version: 0.1.0
+version: 0.1.1

--- a/charts/databases-ephemeral/Chart.yaml
+++ b/charts/databases-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart in-memory, ephemeral databases for use with wire-server https://github.com/wireapp/wire-server
 name: databases-ephemeral
-version: 0.1.0
+version: 0.1.1

--- a/charts/databases-ephemeral/requirements.yaml
+++ b/charts/databases-ephemeral/requirements.yaml
@@ -9,26 +9,26 @@ dependencies:
 # 2. run database cassandra-migrations (done as a pre-install/pre-upgrade hook)
 # 3. install wire-server
 # I.e. cassandra-migrations cannot run before databases are ready, so one cannot make them a pre-install/upgrade hook. Making them a post-install hook also doesn't work:
-# Installing all charts in parallel means brig/galley/gundeck won't start up 
+# Installing all charts in parallel means brig/galley/gundeck won't start up
 # since cassandra-migrations did not yet run; but the cassandra-migrations hook
 # requires all pods to be in a 'Ready' state before starting (condition for post-install); this is impossible.
 #####################################################
 - name: redis-ephemeral
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../redis-ephemeral"
   tags:
     - redis-ephemeral
     - databases-ephemeral
     - demo
 - name: elasticsearch-ephemeral
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../elasticsearch-ephemeral"
   tags:
     - elasticsearch-ephemeral
     - databases-ephemeral
     - demo
 - name: cassandra-ephemeral
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../cassandra-ephemeral"
   tags:
     - cassandra-ephemeral

--- a/charts/elasticsearch-ephemeral/Chart.yaml
+++ b/charts/elasticsearch-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral elasticsearch
 name: elasticsearch-ephemeral
-version: 0.1.0
+version: 0.1.1

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -35,12 +35,7 @@ spec:
         - name: storage
           mountPath: /data
         resources:
-           limits:
-            cpu: "2000m"
-            memory: 4Gi
-           requests:
-            cpu: "500m"
-            memory: 500Mi
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
         - emptyDir:
             medium: ""

--- a/charts/elasticsearch-ephemeral/values.yaml
+++ b/charts/elasticsearch-ephemeral/values.yaml
@@ -5,3 +5,11 @@ image:
 service:
   httpPort: 9200
   transportPort: 9300
+
+resources:
+  limits:
+    cpu: "2000m"
+    memory: 4Gi
+  requests:
+    cpu: "500m"
+    memory: 500Mi

--- a/charts/fake-aws-dynamodb/Chart.yaml
+++ b/charts/fake-aws-dynamodb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral DynamoDB service
 name: fake-aws-dynamodb
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -25,12 +25,7 @@ spec:
         - name: storage
           mountPath: /data
         resources:
-           limits:
-            cpu: "300m"
-            memory: 3000Mi
-           requests:
-            cpu: "100m"
-            memory: 100Mi
+{{ toYaml .Values.resources | indent 12 }}
       - name: create-tables
         image: mesosphere/aws-cli:1.14.5
         command: [/bin/sh]

--- a/charts/fake-aws-dynamodb/values.yaml
+++ b/charts/fake-aws-dynamodb/values.yaml
@@ -5,3 +5,11 @@ image:
 service:
   internalPort: 8000
   externalPort: 4567
+
+resources:
+  limits:
+    cpu: "300m"
+    memory: 3000Mi
+  requests:
+    cpu: "100m"
+    memory: 100Mi

--- a/charts/fake-aws-s3/Chart.yaml
+++ b/charts/fake-aws-s3/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Wrapper chart for stable/minio
 name: fake-aws-s3
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws-ses/Chart.yaml
+++ b/charts/fake-aws-ses/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SES service (based on localstack)
 name: fake-aws-ses
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws-ses/templates/deployment.yaml
+++ b/charts/fake-aws-ses/templates/deployment.yaml
@@ -32,12 +32,7 @@ spec:
         - name: storage
           mountPath: /data
         resources:
-           limits:
-            cpu: "200m"
-            memory: 500Mi
-           requests:
-            cpu: "100m"
-            memory: 100Mi
+{{ toYaml .Values.resources | indent 12 }}
       - name: initiate-fake-aws-ses
         image: mesosphere/aws-cli:1.14.5
         command: [/bin/sh]

--- a/charts/fake-aws-ses/values.yaml
+++ b/charts/fake-aws-ses/values.yaml
@@ -6,5 +6,13 @@ service:
   internalPort: 4579
   externalPort: 4569
 
+resources:
+  limits:
+    cpu: "200m"
+    memory: 500Mi
+  requests:
+    cpu: "100m"
+    memory: 100Mi
+
 ## The following needs to be provided (and consistent with the config in brig)
 #sesSender: "sender@example.com"

--- a/charts/fake-aws-sns/Chart.yaml
+++ b/charts/fake-aws-sns/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SNS service (based on localstack)
 name: fake-aws-sns
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws-sns/templates/deployment.yaml
+++ b/charts/fake-aws-sns/templates/deployment.yaml
@@ -32,12 +32,7 @@ spec:
         - name: storage
           mountPath: /data
         resources:
-           limits:
-            cpu: "200m"
-            memory: 500Mi
-           requests:
-            cpu: "100m"
-            memory: 100Mi
+{{ toYaml .Values.resources | indent 12 }}
       - name: initiate-fake-aws-sns
         image: mesosphere/aws-cli:1.14.5
         command: [/bin/sh]

--- a/charts/fake-aws-sns/values.yaml
+++ b/charts/fake-aws-sns/values.yaml
@@ -5,3 +5,11 @@ image:
 service:
   internalPort: 4575
   externalPort: 4575
+
+resources:
+  limits:
+    cpu: "200m"
+    memory: 500Mi
+  requests:
+    cpu: "100m"
+    memory: 100Mi

--- a/charts/fake-aws-sqs/Chart.yaml
+++ b/charts/fake-aws-sqs/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SQS service
 name: fake-aws-sqs
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws-sqs/templates/deployment.yaml
+++ b/charts/fake-aws-sqs/templates/deployment.yaml
@@ -25,12 +25,7 @@ spec:
         - name: storage
           mountPath: /data
         resources:
-           limits:
-            cpu: "1000m"
-            memory: 1000Mi
-           requests:
-            cpu: "500m"
-            memory: 500Mi
+{{ toYaml .Values.resources | indent 12 }}
       - name: initiate-fake-aws-sqs
         image: mesosphere/aws-cli:1.14.5
         command: [/bin/sh]

--- a/charts/fake-aws-sqs/values.yaml
+++ b/charts/fake-aws-sqs/values.yaml
@@ -11,3 +11,11 @@ queueNames:
 
 service:
   httpPort: 4568
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: 1000Mi
+  requests:
+    cpu: "500m"
+    memory: 500Mi

--- a/charts/fake-aws/Chart.yaml
+++ b/charts/fake-aws/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for fake-aws services (replacing real AWS services for demo and test)
 name: fake-aws
-version: 0.1.0
+version: 0.1.1

--- a/charts/fake-aws/requirements.yaml
+++ b/charts/fake-aws/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
 ## dependent (demo, non-HA) AWS mocks
 #######################################
 - name: fake-aws-sns
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../fake-aws-sns"
   condition: fake-aws-sns.enabled,global.fake-aws-sns.enabled
   tags:
@@ -11,7 +11,7 @@ dependencies:
     - aws-mocks
     - demo
 - name: fake-aws-sqs
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../fake-aws-sqs"
   condition: fake-aws-sqs.enabled,global.fake-aws-sqs.enabled
   tags:
@@ -19,7 +19,7 @@ dependencies:
     - aws-mocks
     - demo
 - name: fake-aws-s3
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../fake-aws-s3"
   condition: fake-aws-s3.enabled,global.fake-aws-s3.enabled
   tags:
@@ -27,7 +27,7 @@ dependencies:
     - aws-mocks
     - demo
 - name: fake-aws-dynamodb
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../fake-aws-dynamodb"
   condition: fake-aws-dynamodb.enabled,global.fake-aws-dynamodb.enabled
   tags:
@@ -35,7 +35,7 @@ dependencies:
     - aws-mocks
     - demo
 - name: fake-aws-ses
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "file://../fake-aws-ses"
   condition: fake-aws-ses.enabled,global.fake-aws-ses.enabled
   tags:

--- a/charts/nginx-lb-ingress/README.md
+++ b/charts/nginx-lb-ingress/README.md
@@ -6,10 +6,10 @@ If tls.enabled == true, then you need to supply 2 variables, `tlsWildcardCert` a
 secrets:
   tlsWildcardCert: |
     -----BEGIN CERTIFICATE-----
-    ....
+    ... (Your Primary SSL certificate) ...
     -----END CERTIFICATE-----
     -----BEGIN CERTIFICATE-----
-    ...
+    ... (Your Intermediate certificate) ...
     -----END CERTIFICATE-----
   tlsWildcardKey: |
     -----BEGIN PRIVATE KEY-----
@@ -20,3 +20,9 @@ secrets:
 or encrypted with `sops` and then use `helm-wrapper`.
 
 Have a look at the [values file](values.yaml) for different configuration options.
+
+# Common issues
+
+Q: My ingress keeps serving "Kubernetes Ingress Controller Fake Certificate"!!
+
+A: Ensure that your certificate is _valid_ and has _not expired_; trying to serve expired certificates will silently fail and the nginx ingress will simply fallback to the default certificate.

--- a/charts/redis-ephemeral/Chart.yaml
+++ b/charts/redis-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Wrapper chart for stable/redis
 name: redis-ephemeral
-version: 0.1.0
+version: 0.1.1

--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -1,4 +1,3 @@
-
 redis-ephemeral:
   usePassword: false
   persistence:
@@ -6,8 +5,8 @@ redis-ephemeral:
 
   resources:
     limits:
-     cpu: 1000m
-     memory: 1024Mi
+      cpu: 1000m
+      memory: 1024Mi
     requests:
-     cpu: 500m
-     memory: 512Mi
+      cpu: 500m
+      memory: 512Mi


### PR DESCRIPTION
In this PR:
 * Improve the demo-setup script slightly to allow skipping the creation of a load balancer on the cluster as well as to skip dependency updates (to speed up helm chart installations - use if you know what u are doing)
 * Allows overriding `resources` for even more minimal demo setups (e.g, there's an installation currently running where `memory requests` are all `"100Mi"`)