### PR TITLE
More templating for brig configmap

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -87,18 +87,34 @@ data:
           {{- end }}
 
       user:
+        {{- if .emailSMS.user }}
+        activationUrl: {{ .emailSMS.user.activationUrl }}
+        smsActivationUrl: {{ .emailSMS.user.smsActivationUrl }}
+        passwordResetUrl: {{ .emailSMS.user.passwordResetUrl }}
+        invitationUrl: {{ .emailSMS.user.invitationUrl }}
+        deletionUrl: {{ .emailSMS.user.deletionUrl }}
+        {{- else }}
         activationUrl: {{ .externalUrls.nginz }}/activate?key=${key}&code=${code}
         smsActivationUrl: {{ .externalUrls.nginz }}/v/${code}
         passwordResetUrl: {{ .externalUrls.nginz }}/password-reset/${key}?code=${code}
         invitationUrl: {{ .externalUrls.nginz }}/register?invitation_code=${code}
         deletionUrl: {{ .externalUrls.nginz }}/users/delete?key=${key}&code=${code}
+        {{- end }}
 
       provider:
+        {{- if .emailSMS.provider }}
+        homeUrl: {{ .emailSMS.provider.homeUrl }}
+        providerActivationUrl: {{ .emailSMS.provider.providerActivationUrl }}
+        approvalUrl: {{ .emailSMS.provider.approvalUrl }}
+        approvalTo: {{ .emailSMS.provider.approvalTo }}
+        providerPwResetUrl: {{ .emailSMS.provider.providerPwResetUrl }}
+        {{- else }}
         homeUrl: https://provider.localhost/
         providerActivationUrl: {{ .externalUrls.nginz }}/provider/activate?key=${key}&code=${code}
         approvalUrl: {{ .externalUrls.nginz }}/provider/approve?key=${key}&code=${code}
         approvalTo: success@simulator.amazonses.com
         providerPwResetUrl: {{ .externalUrls.nginz }}/provider/password-reset?key=\${key}\&code=\${code}
+        {{- end }}
 
       team:
       {{- if .externalUrls.teamSettings }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -87,34 +87,34 @@ data:
           {{- end }}
 
       user:
-        {{- if .emailSMS.user }}
+      {{- if .emailSMS.user }}
         activationUrl: {{ .emailSMS.user.activationUrl }}
         smsActivationUrl: {{ .emailSMS.user.smsActivationUrl }}
         passwordResetUrl: {{ .emailSMS.user.passwordResetUrl }}
         invitationUrl: {{ .emailSMS.user.invitationUrl }}
         deletionUrl: {{ .emailSMS.user.deletionUrl }}
-        {{- else }}
+      {{- else }}
         activationUrl: {{ .externalUrls.nginz }}/activate?key=${key}&code=${code}
         smsActivationUrl: {{ .externalUrls.nginz }}/v/${code}
         passwordResetUrl: {{ .externalUrls.nginz }}/password-reset/${key}?code=${code}
         invitationUrl: {{ .externalUrls.nginz }}/register?invitation_code=${code}
         deletionUrl: {{ .externalUrls.nginz }}/users/delete?key=${key}&code=${code}
-        {{- end }}
+      {{- end }}
 
       provider:
-        {{- if .emailSMS.provider }}
+      {{- if .emailSMS.provider }}
         homeUrl: {{ .emailSMS.provider.homeUrl }}
         providerActivationUrl: {{ .emailSMS.provider.providerActivationUrl }}
         approvalUrl: {{ .emailSMS.provider.approvalUrl }}
         approvalTo: {{ .emailSMS.provider.approvalTo }}
         providerPwResetUrl: {{ .emailSMS.provider.providerPwResetUrl }}
-        {{- else }}
+      {{- else }}
         homeUrl: https://provider.localhost/
         providerActivationUrl: {{ .externalUrls.nginz }}/provider/activate?key=${key}&code=${code}
         approvalUrl: {{ .externalUrls.nginz }}/provider/approve?key=${key}&code=${code}
         approvalTo: success@simulator.amazonses.com
         providerPwResetUrl: {{ .externalUrls.nginz }}/provider/password-reset?key=\${key}\&code=\${code}
-        {{- end }}
+      {{- end }}
 
       team:
       {{- if .externalUrls.teamSettings }}


### PR DESCRIPTION
While the default values are OK for a simple deployment, they do not work for a deployment with account settings pages which need to be able to override those URLs.