### PR TITLE
Add the helm vars for configuring whether emails of team members are visible.

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -164,4 +164,8 @@ data:
       setMaxTeamSize: {{ .setMaxTeamSize }}
       setMaxConvSize: {{ .setMaxConvSize }}
     {{- end }}
+    {{- with .optMutableSettings }}
+    optMutableSettings:
+      setEmailVisibility: {{ .setEmailVisibility }}
+    {{- end }}
   {{- end }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -60,6 +60,8 @@ config:
     setMaxConvAndTeamSize: 128
     setMaxTeamSize: 128
     setMaxConvSize: 128
+  optMutableSettings:
+    setEmailVisibility: visible_to_self
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
 turnStatic:


### PR DESCRIPTION
To enable this feature you need a custom brig image and a configuration override:
Add the following override to your `values.yaml` for your `wire-server` chart

```
brig:
  image:
    tag: 0.0.1-pr.1229
  config:
    optMutableSettings:
      setEmailVisibility: visible_if_on_team
```