### PR TITLE
Rename 'service' to 'role' so dashbaords can be shared between k8s and AWS

### DIFF
--- a/charts/wire-server-metrics/Chart.yaml
+++ b/charts/wire-server-metrics/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Adds monitoring for the kubernetes cluster and wire-server services
 name: wire-server-metrics
-version: 0.1.0
+version: 0.1.1

--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -9,11 +9,11 @@ prometheus-operator:
           - path: '/i/metrics'
             port: http
             interval: 3m
-            metric_relabel_configs:
+            metricRelabelings:
               # Rename 'service' to 'role' to allow sharing of grafana dashboards
               # between k8s and AWS services.
-              - source_labels: [service]
-                target_label: role
+              - sourceLabels: [service]
+                targetLabel: role
         namespaceSelector:
           # The namespaces which we can monitor are still limited by the 
           # `prometheus.rbac.roleNamespaces` rules

--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -9,6 +9,11 @@ prometheus-operator:
           - path: '/i/metrics'
             port: http
             interval: 3m
+            metric_relabel_configs:
+              # Rename 'service' to 'role' to allow sharing of grafana dashboards
+              # between k8s and AWS services.
+              - source_labels: [service]
+                target_label: role
         namespaceSelector:
           # The namespaces which we can monitor are still limited by the 
           # `prometheus.rbac.roleNamespaces` rules


### PR DESCRIPTION
Add a prometheus renaming rule so our grafana dashboards are shareable everywhere.

I could have also done it in the opposite direction; but this is easier to avoid metrics downtime.