### PR TITLE
Add Turn configs for brig integration tests

### DIFF
--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -47,6 +47,10 @@ spec:
   - name: integration
     image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
     # TODO: Add TURN tests once we have an actual way to test it
+    # The brig-integration tests mutate the turn settings files before tests
+    # to get certain behaviour. This doesn't work on kubernetes because brig
+    # is a different pod than brig-integration and they can't both mouht the
+    # same file-system.
     command: ["brig-integration", "--pattern", "!/turn/"]
     volumeMounts:
     - name: "brig-integration"

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -37,6 +37,9 @@ spec:
     - name: "brig-secrets"
       secret:
         secretName: "brig"
+    - name: "turn-servers"
+      configMap:
+        name: "turn"
     - name: "brig-integration-secrets"
       configMap:
         name: "brig-integration-secrets"
@@ -52,12 +55,15 @@ spec:
       mountPath: "/etc/wire/brig/conf"
     - name: "brig-secrets"
       mountPath: "/etc/wire/brig/secrets"    
+    - name: "turn-servers"
+      mountPath: "/etc/wire/brig/turn"
     - name: "brig-integration-secrets"
       # TODO: Maybe we should put integration yaml also under
       #       `/integration/conf` by default? Note that currently
       #       brig-integration cannot read config files from
       #       non-default locations
       mountPath: "/etc/wire/integration-secrets"
+
     env:
     # these dummy values are necessary for Amazonka's "Discover"
     - name: AWS_ACCESS_KEY_ID

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -47,7 +47,7 @@ spec:
   - name: integration
     image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
     # TODO: Add TURN tests once we have an actual way to test it
-    command: ["brig-integration", "--pattern", "!/turn/"]
+    command: ["brig-integration"]
     volumeMounts:
     - name: "brig-integration"
       mountPath: "/etc/wire/integration"

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -47,7 +47,7 @@ spec:
   - name: integration
     image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
     # TODO: Add TURN tests once we have an actual way to test it
-    command: ["brig-integration"]
+    command: ["brig-integration", "--pattern", "!/turn/"]
     volumeMounts:
     - name: "brig-integration"
       mountPath: "/etc/wire/integration"


### PR DESCRIPTION
It appears from Concourse that the turn files aren't mounted in the integration test container causing my latest PR in wire-server to fail. https://github.com/wireapp/wire-server-deploy/pull/53

Not entirely sure this is done correctly so please look over it with a discerning eye haha.

Note this:

https://github.com/wireapp/wire-server-deploy/blob/master/charts/brig/templates/tests/brig-integration.yaml#L46-L47

>     # TODO: Add TURN tests once we have an actual way to test it
>    command: ["brig-integration", "--pattern", "!/turn/"]

Seems as though we're not running turn related tests on purpose? Anyone know why? @tiago-loureiro @jschaul 