### PR TITLE
add s3-minio AWS ELB support

### DIFF
--- a/charts/aws-ingress/Chart.yaml
+++ b/charts/aws-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for ingresses (AWS specific) on Kubernetes
 name: aws-ingress
-version: 0.1.0
+version: 0.1.1

--- a/charts/aws-ingress/templates/ELB_s3-minio_https.yaml
+++ b/charts/aws-ingress/templates/ELB_s3-minio_https.yaml
@@ -1,0 +1,25 @@
+{{- with .Values.ingress.s3-minio }}
+{{- if .enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: s3-elb-https
+  annotations:
+    # annotations are documented under https://kubernetes.io/docs/concepts/services-networking/service/
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "{{ .https.externalPort }}"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .https.sslCert }}"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "{{ .https.sslPolicy }}"
+    external-dns.alpha.kubernetes.io/hostname:   "{{ .https.hostname }}"
+    external-dns.alpha.kubernetes.io/ttl: "{{ .https.ttl }}"
+spec:
+  type: LoadBalancer
+  selector:
+    {{ .selector.key }}: {{ .selector.value }}
+  ports:
+  - name: https
+    protocol: TCP
+    port: {{ .https.externalPort }}
+    # NOTE: This value should match s3 http listening port on the s3 service (minio)
+    targetPort: {{ .http.s3Port }}
+{{- end }}

--- a/charts/aws-ingress/templates/ELB_s3minio_https.yaml
+++ b/charts/aws-ingress/templates/ELB_s3minio_https.yaml
@@ -1,4 +1,4 @@
-{{- with .Values.ingress.s3-minio }}
+{{- with .Values.ingress.s3minio }}
 {{- if .enabled }}
 kind: Service
 apiVersion: v1
@@ -22,4 +22,5 @@ spec:
     port: {{ .https.externalPort }}
     # NOTE: This value should match s3 http listening port on the s3 service (minio)
     targetPort: {{ .http.s3Port }}
+{{- end }}
 {{- end }}

--- a/charts/aws-ingress/values.yaml
+++ b/charts/aws-ingress/values.yaml
@@ -43,4 +43,4 @@ ingress:
       s3Port: 9000
     selector:
       key: app
-      value: minio
+      value: minio # (currently) fake-aws-s3 chart uses 'minio', minio-external chart uses 'minio-external'

--- a/charts/aws-ingress/values.yaml
+++ b/charts/aws-ingress/values.yaml
@@ -31,7 +31,7 @@ ingress:
       ttl: 300
     ws:
       wsPort: 8081
-  s3-minio:
+  s3minio:
     enabled: false # set to true if you wish to use minio on AWS instead of using real S3
     https:
       externalPort: 443

--- a/charts/aws-ingress/values.yaml
+++ b/charts/aws-ingress/values.yaml
@@ -31,3 +31,16 @@ ingress:
       ttl: 300
     ws:
       wsPort: 8081
+  s3-minio:
+    enabled: false # set to true if you wish to use minio on AWS instead of using real S3
+    https:
+      externalPort: 443
+      sslCert: arn:aws:iam::00000-accountnumber-00000:server-certificate/example.com
+      sslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+      hostname: <prefix>-s3-https.<domain>
+      ttl: 300
+    http:
+      s3Port: 9000
+    selector:
+      key: app
+      value: minio


### PR DESCRIPTION
Can be useful to test minio on AWS; or, for ephemeral environments, to avoid configuring secrets and buckets on real S3.
(disabled by default - when using AWS, one has access to real S3)