### PR TITLE
Update chart version for minio dependency

### DIFF
--- a/charts/fake-aws-s3/requirements.yaml
+++ b/charts/fake-aws-s3/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: minio
-  version: 1.8.1
+  version: 2.4.14
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
untested if everything still works. May fix https://github.com/wireapp/wire-server-deploy/pull/46 (which has no effect currently).