### PR TITLE
fix for galley-integration.

### DIFF
--- a/charts/galley/templates/tests/galley-integration.yaml
+++ b/charts/galley/templates/tests/galley-integration.yaml
@@ -1,4 +1,22 @@
 apiVersion: v1
+kind: Service
+metadata:
+  name: "galley-integration"
+  labels:
+    wireService: galley-integration
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+  selector:
+    wireService: galley-integration
+    release: {{ .Release.Name }}
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-galley-integration"

--- a/charts/galley/templates/tests/galley-integration.yaml
+++ b/charts/galley/templates/tests/galley-integration.yaml
@@ -22,6 +22,9 @@ metadata:
   name: "{{ .Release.Name }}-galley-integration"
   annotations:
     "helm.sh/hook": test-success
+  labels:
+    wireService: galley-integration
+    release: {{ .Release.Name }}
 spec:
   volumes:
     - name: "galley-integration"


### PR DESCRIPTION
fixes missing configuration in #61 and #62

Galley can't contact the galley-integration mock service if it's not reachable.