### PR TITLE
Fix: url trailing slashes

### DIFF
--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -34,11 +34,11 @@ spec:
           - name: NODE_PORT
             value: "{{ .Values.service.http.internalPort }}"
           - name: APP_BASE
-            value: https://{{ .Values.config.externalUrls.appHost }}
+            value: "https://{{ .Values.config.externalUrls.appHost }}"
           - name: BACKEND_REST
-            value: https://{{ .Values.config.externalUrls.backendRest }}
+            value: "https://{{ .Values.config.externalUrls.backendRest }}"
           - name: BACKEND_WS
-            value: wss://{{ .Values.config.externalUrls.backendWebsocket }}
+            value: "wss://{{ .Values.config.externalUrls.backendWebsocket }}"
       {{- range $key, $val := .Values.envVars }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -30,10 +30,11 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         # Check variables here: https://github.com/wireapp/wire-webapp/wiki/Self-hosting
         env:
+          # it is vital that you don't add trailing '/' in this section!
           - name: NODE_PORT
             value: "{{ .Values.service.http.internalPort }}"
           - name: APP_BASE
-            value: https://{{ .Values.config.externalUrls.appHost }}/
+            value: https://{{ .Values.config.externalUrls.appHost }}
           - name: BACKEND_REST
             value: https://{{ .Values.config.externalUrls.backendRest }}
           - name: BACKEND_WS


### PR DESCRIPTION
Without this fix, `/join/?key=....` urls have two slashes in front of `/join`, which causes a 404.

Related: https://github.com/wireapp/wire-server-deploy/blob/master/charts/webapp/templates/deployment.yaml#L35-L36

It's a bit unfortunate that APP_BASE can't be overwritten, and that `//` handling is so brittle.  Not sure how to fix this, though.  Perhaps remove these `env` entries entirely where they can be declared explicitly, rather than fixing them a little for this instance?