### PR TITLE
nginx-ingress increased buffer size

### DIFF
--- a/values/nginx-lb-ingress/prod-values.example.yaml
+++ b/values/nginx-lb-ingress/prod-values.example.yaml
@@ -27,7 +27,14 @@ service:
 #                setup when all your k8s nodes are on internal IPs and thus this requires
 #                setting up your firewall and forward 443 to 31773, as well as 80 to 31772
 nginx-ingress:
+  defaultBackend:
+    image:
+      imagePullPolicy: IfNotFound
   controller:
+    image:
+      imagePullPolicy: IfNotFound
+    config:
+      proxy-buffer-size: "16k"
     service:
       type: NodePort
       nodePorts:


### PR DESCRIPTION
502 due to 'upstream sent too big header while reading response header
from upstream'

See https://andrewlock.net/fixing-nginx-upstream-sent-too-big-header-error-when-running-an-ingress-controller-in-kubernetes/