### PR TITLE
Recreate tables if needed

### DIFF
--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -32,19 +32,33 @@ spec:
         args:
         - -c
         - |
+          exec_until_ready() {
+              until $1; do echo 'service not ready yet'; sleep 1; done
+          }
+          table_exists() {
+              OUTPUT=$(aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb list-tables | grep $1 | wc -l)
+              echo $OUTPUT
+          }
           echo 'Creating AWS resources'
           aws configure set aws_access_key_id dummy
           aws configure set aws_secret_access_key dummy
           aws configure set region eu-west-1
 
-          # Create resources
-          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-userkey-blacklist --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
-          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-prekeys --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
-
           while true
           do
-              echo "Resources created, sleeping for 30, to keep this container (and thus the pod) alive"
-              sleep 30
+              # Recreate resources if needed
+              TABLE=$(table_exists "{{ $.Values.tables.brigUserkeyBlacklist }}")
+              if [ "$TABLE" == "1" ]
+                then echo "Table {{ $.Values.tables.brigUserkeyBlacklist }} exists, no need to re-create"
+                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigUserkeyBlacklist }} --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
+              fi
+              TABLE=$(table_exists "{{ $.Values.tables.brigPrekeys }}")
+              if [ "$TABLE" == "1" ]
+                then echo "Table {{ $.Values.tables.brigPrekeys }} exists, no need to re-create"
+                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigPrekeys }} --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
+              fi
+              echo 'Sleeping 10'
+              sleep 10
           done
       volumes:
         - emptyDir: {}

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -32,33 +32,19 @@ spec:
         args:
         - -c
         - |
-          exec_until_ready() {
-              until $1; do echo 'service not ready yet'; sleep 1; done
-          }
-          table_exists() {
-              OUTPUT=$(aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb list-tables | grep $1 | wc -l)
-              echo $OUTPUT
-          }
           echo 'Creating AWS resources'
           aws configure set aws_access_key_id dummy
           aws configure set aws_secret_access_key dummy
           aws configure set region eu-west-1
 
+          # Create resources
+          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-userkey-blacklist --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
+          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-prekeys --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
+
           while true
           do
-              # Recreate resources if needed
-              TABLE=$(table_exists "{{ $.Values.tables.brigPrekeys }}")
-              if [ "$TABLE" == "1" ]
-                then echo "Table {{ $.Values.tables.brigPrekeys }} exists, no need to re-create"
-                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigPrekeys }} --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
-              fi
-              TABLE=$(table_exists "{{ $.Values.tables.brigUserkeyBlacklist }}")
-              if [ "$TABLE" == "1" ]
-                then echo "Table {{ $.Values.tables.brigUserkeyBlacklist }} exists, no need to re-create"
-                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigUserkeyBlacklist }} --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
-              fi
-              echo 'Sleeping 10'
-              sleep 10
+              echo "Resources created, sleeping for 30, to keep this container (and thus the pod) alive"
+              sleep 30
           done
       volumes:
         - emptyDir: {}

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -32,19 +32,33 @@ spec:
         args:
         - -c
         - |
+          exec_until_ready() {
+              until $1; do echo 'service not ready yet'; sleep 1; done
+          }
+          table_exists() {
+              OUTPUT=$(aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb list-tables | grep $1 | wc -l)
+              echo $OUTPUT
+          }
           echo 'Creating AWS resources'
           aws configure set aws_access_key_id dummy
           aws configure set aws_secret_access_key dummy
           aws configure set region eu-west-1
 
-          # Create resources
-          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-userkey-blacklist --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
-          until aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name integration-brig-prekeys --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5; do echo 'dynamodb not ready yet'; sleep 1; done
-
           while true
           do
-              echo "Resources created, sleeping for 30, to keep this container (and thus the pod) alive"
-              sleep 30
+              # Recreate resources if needed
+              TABLE=$(table_exists "{{ $.Values.tables.brigPrekeys }}")
+              if [ "$TABLE" == "1" ]
+                then echo "Table {{ $.Values.tables.brigPrekeys }} exists, no need to re-create"
+                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigPrekeys }} --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
+              fi
+              TABLE=$(table_exists "{{ $.Values.tables.brigUserkeyBlacklist }}")
+              if [ "$TABLE" == "1" ]
+                then echo "Table {{ $.Values.tables.brigUserkeyBlacklist }} exists, no need to re-create"
+                else exec_until_ready "aws --endpoint-url=http://localhost:{{ $.Values.service.internalPort }} dynamodb create-table --table-name {{ $.Values.tables.brigUserkeyBlacklist }} --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
+              fi
+              echo 'Sleeping 10'
+              sleep 10
           done
       volumes:
         - emptyDir: {}

--- a/charts/fake-aws-dynamodb/values.yaml
+++ b/charts/fake-aws-dynamodb/values.yaml
@@ -6,6 +6,10 @@ service:
   internalPort: 8000
   externalPort: 4567
 
+tables:
+  brigPrekeys: integration-brig-prekeys
+  brigUserkeyBlacklist: integration-brig-userkey-blacklist
+
 resources:
   limits:
     cpu: "300m"


### PR DESCRIPTION
In case the dynamodb pod dies/gets restarted, we want to recreate these tables otherwise dynamodb remains in a "broken" state (i.e., no tables).

A more elegant way would be to use `postStart` hooks but that'd require having the `aws` on the dynamodb container (which is not there...)