### PR TITLE
Ansible restund example root and tls and download if needed

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -37,7 +37,7 @@
 
 - src: git+https://github.com/wireapp/ansible-restund.git
   name: ansible-restund
-  version: a05788c8514e01867e34f31dc866d79c9916a3e2
+  version: v0.1.3
 
 - src: git+https://github.com/wireapp/ansible-tinc.git
   name: ansible-tinc

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -37,7 +37,7 @@
 
 - src: git+https://github.com/wireapp/ansible-restund.git
   name: ansible-restund
-  version: 18969531d355f7e679c629b599aa8a6d71497b5b
+  version: a05788c8514e01867e34f31dc866d79c9916a3e2
 
 - src: git+https://github.com/wireapp/ansible-tinc.git
   name: ansible-tinc

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -37,7 +37,7 @@
 
 - src: git+https://github.com/wireapp/ansible-restund.git
   name: ansible-restund
-  version: f82e65ae6d84a700af954977194798ef77da7f62
+  version: 18969531d355f7e679c629b599aa8a6d71497b5b
 
 - src: git+https://github.com/wireapp/ansible-tinc.git
   name: ansible-tinc

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -37,7 +37,7 @@
 
 - src: git+https://github.com/wireapp/ansible-restund.git
   name: ansible-restund
-  version: v0.1.0
+  version: f82e65ae6d84a700af954977194798ef77da7f62
 
 - src: git+https://github.com/wireapp/ansible-tinc.git
   name: ansible-tinc

--- a/ansible/restund.yml
+++ b/ansible/restund.yml
@@ -1,4 +1,22 @@
 ---
+- name: gather tls certificate
+  hosts: localhost
+  pre_tasks:
+    - name: Read TLS config
+      set_fact:
+        # Reminder that the pem file should look like:
+        # -----BEGIN CERTIFICATE-----
+        # --- ... CERT CONTENT ... --
+        # -----END CERTIFICATE-----
+        # -----BEGIN CERTIFICATE-----
+        # --- ... INTERMEDIATE ..----
+        # -----END CERTIFICATE----
+        # -----BEGIN PRIVATE KEY-----
+        # --- .... PRIV KEY -----
+        # -----END PRIVATE KEY-----
+
+        restund_tls_certificate: "{{ lookup('file', '/tmp/tls_cert_and_priv_key.pem') }}"
+
 - name: provision
   hosts: restund
   gather_facts: yes
@@ -8,14 +26,15 @@
       # More info to be found at the [demo-secrets.yaml](https://github.com/wireapp/wire-server-deploy/blob/master/values/wire-server/demo-secrets.example.yaml#L9-L12)"
     - name: restund_zrest_secret
       prompt: "Enter the restund_zrest_secret, which must match the brig.secrets.turn.secret in the helm configuration."
+  vars:
+    # This config will make restund run as root and listen on ports 80 and 443
+    - restund_user: root
+    - restund_tls_certificate: "{{ hostvars.localhost.restund_tls_certificate }}"
+    - restund_udp_listen_port: 80
+    - restund_tcp_listen_port: 80
+    - restund_tls_listen_port: 443
   roles:
     - role: hostname
-      vars:
-        - restund_user: root
-        - restund_udp_listen_port: 80
-        - restund_tcp_listen_port: 80
-      # TODO: Add when supported
-      # - restund_tls_listen_port: 443
       tags:
         - hostname
 

--- a/ansible/restund.yml
+++ b/ansible/restund.yml
@@ -1,22 +1,13 @@
----
-- name: gather tls certificate
-  hosts: localhost
-  pre_tasks:
-    - name: Read TLS config
-      set_fact:
-        # Reminder that the pem file should look like:
-        # -----BEGIN CERTIFICATE-----
-        # --- ... CERT CONTENT ... --
-        # -----END CERTIFICATE-----
-        # -----BEGIN CERTIFICATE-----
-        # --- ... INTERMEDIATE ..----
-        # -----END CERTIFICATE----
-        # -----BEGIN PRIVATE KEY-----
-        # --- .... PRIV KEY -----
-        # -----END PRIVATE KEY-----
-
-        restund_tls_certificate: "{{ lookup('file', '/tmp/tls_cert_and_priv_key.pem') }}"
-
+# Reminder that the pem file should look like:
+# -----BEGIN CERTIFICATE-----
+# --- ... CERT CONTENT ... --
+# -----END CERTIFICATE-----
+# -----BEGIN CERTIFICATE-----
+# --- ... INTERMEDIATE ..----
+# -----END CERTIFICATE----
+# -----BEGIN PRIVATE KEY-----
+# --- .... PRIV KEY -----
+# -----END PRIVATE KEY-----
 - name: provision
   hosts: restund
   gather_facts: yes
@@ -29,7 +20,7 @@
   vars:
     # This config will make restund run as root and listen on ports 80 and 443
     - restund_user: root
-    - restund_tls_certificate: "{{ hostvars.localhost.restund_tls_certificate }}"
+    - restund_tls_certificate: "{{ lookup('file', '/tmp/tls_cert_and_priv_key.pem') }}"
     - restund_udp_listen_port: 80
     - restund_tcp_listen_port: 80
     - restund_tls_listen_port: 443

--- a/ansible/restund.yml
+++ b/ansible/restund.yml
@@ -10,6 +10,12 @@
       prompt: "Enter the restund_zrest_secret, which must match the brig.secrets.turn.secret in the helm configuration."
   roles:
     - role: hostname
+      vars:
+        - restund_user: root
+        - restund_udp_listen_port: 80
+        - restund_tcp_listen_port: 80
+      # TODO: Add when supported
+      # - restund_tls_listen_port: 443
       tags:
         - hostname
 


### PR DESCRIPTION
Uses the latest available version from the ansible restund playbook.