### PR TITLE
Specify namespace too when advertising

### DIFF
--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -1,6 +1,9 @@
 # Spins up pods with stable names; e.g. cannon-0 ... cannon-<replicaCount>
-# Specific pods can be accessed within the cluster at cannon-<n>.cannon
+# Specific pods can be accessed within the cluster at cannon-<n>.cannon.<namespace>
 # (the second 'cannon' is the name of the headless service)
+# Note: In fact, cannon-<n>.cannon can also be used to access the service but assuming
+# that we can have multiple namespaces accessing the same redis cluster, appending `.<namespace>`
+# makes the service unambiguous
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 # Spins up pods with stable names; e.g. cannon-0 ... cannon-<replicaCount>
-# Specific pods can be accessed within the cluster at cannon-<n>.cannon 
+# Specific pods can be accessed within the cluster at cannon-<n>.cannon
 # (the second 'cannon' is the name of the headless service)
 apiVersion: apps/v1
 kind: StatefulSet
@@ -68,7 +68,7 @@ spec:
         args:
         - -c
         # e.g. cannon-0.cannon
-        - echo "${HOSTNAME}.{{ .Values.service.name }}" > /etc/wire/cannon/externalHost/host.txt
+        - echo "${HOSTNAME}.{{ .Values.service.name }}.{{ .Release.Namespace }}" > /etc/wire/cannon/externalHost/host.txt
         volumeMounts:
         - name: empty
           mountPath: /etc/wire/cannon/externalHost


### PR DESCRIPTION
We typically leave out the namespace from service names because they are anyway scoped and assumed if not specified.

However, there are cases in which you have a shared database (redis) and in such cases it's important to distinguish which cannon are you actually trying to connect to - there might also be cases where you _do want to talk across namespaces_