### PR TITLE
version lock nginz_disco

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -9,7 +9,7 @@ resources:
 images:
   nginzDisco:
     repository: quay.io/wire/nginz_disco
-    tag: latest
+    tag: 1.0.1
   nginz:
     repository: quay.io/wire/nginz
     tag: 2.58.0


### PR DESCRIPTION
* New version of nginz_disco from https://github.com/wireapp/wire-server/pull/759
* version-lock this docker image, rather than using "latest".