### PR TITLE
Limit ssl ciphers by default

### DIFF
--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -3,13 +3,13 @@
 nginx-ingress:
   controller:
     config:
+      # NOTE: These are some sane defaults, you may want to overrride them on your own installation
+      ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256"
       http2-max-field-size: 16k
       http2-max-header-size: 32k
       proxy-buffer-size: 16k
       proxy-body-size: 1024m
 
-  # NOTE: You may want to add the following options on your own installation
-  #   ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256"
   # service:
   #   type: NodePort
   #   nodePorts:


### PR DESCRIPTION
Moving to these ciphers by default gets us an A+ according to http://ssllabs.com/ssltest/analyze.html