### PR TITLE
Upgrade prometheus-operator and adjust docs

### DIFF
--- a/charts/wire-server-metrics/Chart.yaml
+++ b/charts/wire-server-metrics/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Adds monitoring for the kubernetes cluster and wire-server services
 name: wire-server-metrics
-version: 0.1.1
+version: 0.1.2

--- a/charts/wire-server-metrics/README.md
+++ b/charts/wire-server-metrics/README.md
@@ -1,0 +1,15 @@
+wire-server-metrics
+-------------------
+
+ This is mostly a wrapper over https://github.com/helm/charts/tree/master/stable/prometheus-operator
+For a full list of overrides, please check the appropriate chart version and its options.
+
+ How to use this chart?
+----------------------
+
+ In its simplest form, install the chart with:
+```
+helm upgrade --install --namespace <namespace> <name> charts/wire-server-metrics [-f <optional-path-to-overrides>
+```
+
+For more detailed information on how to set up monitoring on your cluster, go to the [monitoring page](../docs/monitoring.md)

--- a/charts/wire-server-metrics/requirements.yaml
+++ b/charts/wire-server-metrics/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
   - name: prometheus-operator
-    version: 5.0.4
+    version: 6.7.2
     repository: "@stable"

--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -52,24 +52,15 @@ prometheus-operator:
             options:
               path: /var/lib/grafana/dashboards/default
 
-    # TODO: Chart importing is broken for the time being; should be fixed in
-    # a release soon.
-    # REF: https://github.com/helm/charts/issues/12352
-    #      https://github.com/helm/charts/pull/12512
-    # dashboards:
-    #   default:
-    #     # grafana can only access files from within its own chart directory
-    #     # which we don't have access to here; we can either dump the json
-    #     # directly into the values file, or load from a url
-
-    #     brig:
-    #       url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/cp/prometheus-operator/charts/wire-server-metrics/dashboards/brig.json
-    #     cannon:
-    #       url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/cp/prometheus-operator/charts/wire-server-metrics/dashboards/cannon.json
-    #     galley:
-    #       url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/cp/prometheus-operator/charts/wire-server-metrics/dashboards/galley.json
-    #     gundeck:
-    #       url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/cp/prometheus-operator/charts/wire-server-metrics/dashboards/gundeck.json
+    dashboards:
+      default:
+        # grafana can only access files from within its own chart directory
+        # which we don't have access to here; we can either dump the json
+        # directly into the values file, or load from a url
+        messages:
+          url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/master/charts/wire-server-metrics/dashboards/message-stats.json
+        services:
+          url: https://raw.githubusercontent.com/wireapp/wire-server-deploy/master/charts/wire-server-metrics/dashboards/services.json
 
   prometheusSpec:
     storageSpec:

--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -14,9 +14,9 @@ prometheus-operator:
               # between k8s and AWS services.
               - sourceLabels: [service]
                 targetLabel: role
+        # This monitors _all_ namespaces and selects all
+        # pods that with a wireServices selector
         namespaceSelector:
-          # The namespaces which we can monitor are still limited by the 
-          # `prometheus.rbac.roleNamespaces` rules
           any: true
         selector:
           matchExpressions:
@@ -52,7 +52,7 @@ prometheus-operator:
             options:
               path: /var/lib/grafana/dashboards/default
 
-    # TODO: Chart importing is broken for the time being; should be fixed in 
+    # TODO: Chart importing is broken for the time being; should be fixed in
     # a release soon.
     # REF: https://github.com/helm/charts/issues/12352
     #      https://github.com/helm/charts/pull/12512
@@ -91,7 +91,3 @@ prometheus-operator:
             resources:
               requests:
                 storage: 10Gi
-  coreDns:
-    enabled: false
-  kubeDns:
-    enabled: true

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -139,9 +139,6 @@ prometheus-operator:
   grafana:
     persistence:
       enabled: false
-    extraEmptyDirMounts:
-      - name: dashboards-dir
-        mountPath: /var/lib/grafana/dashboards/default
   prometheusSpec:
     storageSpec: null
   alertmanager:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -86,19 +86,9 @@ Grafana's web UI. See [Accessing grafana](#accessing-grafana).
 
 It is advisable to separate your monitoring services from your application services.
 To accomplish this you may deploy `wire-server-metrics` into a separate namespace from
-`wire-server`. Simply provide a different namespace to the `helm upgrade --install` calls
-and adjust the following config option in your `values.yaml`:
+`wire-server`. Simply provide a different namespace to the `helm upgrade --install` calls.
 
-```yaml
-wire-server-metrics:
-  prometheus-operator:
-    prometheus:
-        rbac:
-        # Namespaces which may be monitored by prometheus
-        roleNamespaces:
-            - kube-system
-            - <my-wire-server-namespace>
-```
+This chart will monitor all wire services across _all_ namespaces.
 
 ## Using Custom Storage Classes
 
@@ -113,8 +103,8 @@ If you receive the following error:
 
 ```
 Error: validation failed: [unable to recognize "": no matches for kind "Alertmanager" in version
-"monitoring.coreos.com/v1", unable to recognize "": no matches for kind "Prometheus" in version 
-"monitoring.coreos.com/v1", unable to recognize "": no matches for kind "PrometheusRule" in version 
+"monitoring.coreos.com/v1", unable to recognize "": no matches for kind "Prometheus" in version
+"monitoring.coreos.com/v1", unable to recognize "": no matches for kind "PrometheusRule" in version
 ```
 
 Please run the script to install Custom Resource Definitions which is detailed in
@@ -145,11 +135,13 @@ If you wish to deploy monitoring without any persistent disk (not recommended)
 you may add the following overrides to your `values.yaml` file.
 
 ```yaml
-wire-server-metrics:
-  prometheus-operator:
-    grafana:
-      persistence:
-        enabled: false
+prometheus-operator:
+  grafana:
+    persistence:
+      enabled: false
+    extraEmptyDirMounts:
+      - name: dashboards-dir
+        mountPath: /var/lib/grafana/dashboards/default
   prometheusSpec:
     storageSpec: null
   alertmanager:
@@ -163,22 +155,21 @@ If you wish to use a different storage class (for instance if you don't run on A
 you may add the following overrides to your `values.yaml` file.
 
 ```yaml
-wire-server-metrics:
-  prometheus-operator:
-    grafana:
-      persistence:
+prometheus-operator:
+  grafana:
+    persistence:
+      storageClassName: "<my-storage-class>"
+prometheusSpec:
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
         storageClassName: "<my-storage-class>"
-  prometheusSpec:
-    storageSpec: 
+alertmanager:
+  alertmanagerSpec:
+    storage:
       volumeClaimTemplate:
         spec:
           storageClassName: "<my-storage-class>"
-  alertmanager:
-    alertmanagerSpec:
-      storage:
-        volumeClaimTemplate:
-          spec:
-            storageClassName: "<my-storage-class>"
 ```
 
 ## Accessing grafana


### PR DESCRIPTION
Tested with `helm v2.13.1` and on a non-AWS cluster with the following yaml:

```
prometheus-operator:
  grafana:
    persistence:
      enabled: false
    extraEmptyDirMounts:
      - name: dashboards-dir
        mountPath: /var/lib/grafana/dashboards/default
  prometheusSpec:
    storageSpec: null
  alertmanager:
    alertmanagerSpec:
        storage: null
``` 