### PR TITLE
legal hold tokens

### DIFF
--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -20,6 +20,10 @@ data:
       host: cargohold
       port: 8080
 
+    nginz:
+      host: nginz
+      port: 8080
+
     provider:
       privateKey: /etc/wire/integration-secrets/provider-privatekey.pem
       publicKey: /etc/wire/integration-secrets/provider-publickey.pem

--- a/charts/nginz/conf/static/zauth.acl
+++ b/charts/nginz/conf/static/zauth.acl
@@ -4,8 +4,6 @@ a (blacklist (path "/provider")
              (path "/bot/**")
              (path "/i/**"))
 
-u (whitelist (path "/access"))
-
 b (whitelist (path "/bot")
              (path "/bot/**"))
 

--- a/charts/nginz/conf/static/zauth.acl
+++ b/charts/nginz/conf/static/zauth.acl
@@ -12,3 +12,7 @@ b (whitelist (path "/bot")
 p (whitelist (path "/provider")
              (path "/provider/**"))
 
+# LegalHold Access Tokens
+la (whitelist (path "/notifications")
+              (path "/assets/v3/**")
+              (path "/users/**"))


### PR DESCRIPTION
* for integration tests, brig now also depends on nginz
* nginz acl file updated
* whitelisting /access for user tokens has no effect, as that route is not zauth-authenticated

Needed for https://github.com/wireapp/wire-server/pull/761