### PR TITLE
Make the update.sh script take a _path_ instead of a _name_

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If submitting pull requests, please follow these guidelines:
 
 * if you want to make larger changes, it might be best to first open an issue to discuss the change.
 * if helm charts are involved, 
-    * use the `./bin/update.sh <chart-name>` script, to ensure changes in a subchart (e.g. brig) are correctly propagated to the parent chart (e.g. wire-server) before linting or installing.
+    * use the `./bin/update.sh ./charts/<chart-name>` script, to ensure changes in a subchart (e.g. brig) are correctly propagated to the parent chart (e.g. wire-server) before linting or installing.
     * ensure they pass linting, you can check with `helm lint -f path/to/extra/values-file.yaml charts/mychart`. 
     * If you can, try to also install the chart to see if they work the way you intended.
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-USAGE="download and bundle dependent helm charts: $0 <chart-directory>"
-chart=${1:?$USAGE}
-
-BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
-CHARTS_DIR="$BASE_DIR/charts"
-
 set -e
+
+USAGE="download and bundle dependent helm charts: $0 <chart-directory>"
+dir=${1:?$USAGE}
+
 
 # nothing serves on localhost, remove that repo
 helm repo remove local 2&> /dev/null || true
@@ -31,4 +29,4 @@ helmDepUp () {
     fi
 }
 
-helmDepUp "${CHARTS_DIR}/${chart}"
+helmDepUp "$dir"

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -5,7 +5,7 @@ Apart from the usual development setup, you'll additionally need [yq](https://gi
 For local development, instead of `helm install wire/<chart-name>`, use
 
 ```
-./bin/update.sh <chart-name> # this will clean and re-package subcharts
+./bin/update.sh ./charts/<chart-name> # this will clean and re-package subcharts
 helm install charts/<chart-name> # specify a local file path
 ```
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -66,7 +66,7 @@ Now we can install the metrics chart; from the root of the `wire-server-deploy`
 repository run the following:
 
 ```
-./bin/update.sh charts/wire-server-metrics
+./bin/update.sh ./charts/wire-server-metrics
 helm upgrade --install demo-wire-server-metrics wire/wire-server-metrics \
     --namespace demo \
     --wait


### PR DESCRIPTION
This means I can do:

`/bin/update.sh charts/wire-se<TAB>`  and it auto-completes to the right
chart name, which saves me 10 seconds per day and makes me not have to
know a chart name apriori. I think the UX is a lot better, as we get
free completion of what charts are available


Not a really important change, just something that made things a bit easier for me when working with these scripts interactively