### PR TITLE
Configure brig and galley to produce JSON logs

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   brig.yaml: |
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
-    logFormat: {{ . logFormat }}
+    logFormat: {{ .logFormat }}
     logLevel: {{ .logLevel }}
 
     brig:

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   brig.yaml: |
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
+    logFormat: JSON
     logLevel: {{ .logLevel }}
 
     brig:

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   brig.yaml: |
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
-    logFormat: JSON
+    logFormat: {{ . logFormat }}
     logLevel: {{ .logLevel }}
 
     brig:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/turnconfigmap: {{ include (print .Template.BasePath "/turnconfigmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        fluentbit.io/parser: json
     spec:
       volumes:
         - name: "brig-config"

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 512Mi
     cpu: 500m
 config:
-  logLevel: Debug
+  logLevel: Info
   logFormat: JSON
   cassandra:
     host: aws-cassandra

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 512Mi
     cpu: 500m
 config:
-  logLevel: Info
+  logLevel: Debug
   cassandra:
     host: aws-cassandra
   elasticsearch:

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -14,6 +14,7 @@ resources:
     cpu: 500m
 config:
   logLevel: Debug
+  logFormat: JSON
   cassandra:
     host: aws-cassandra
   elasticsearch:

--- a/charts/fluent-bit/requirements.yaml
+++ b/charts/fluent-bit/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: fluent-bit
-  version: 1.9.1
+  version: 2.7.0
   repository: https://kubernetes-charts.storage.googleapis.com

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -4,4 +4,9 @@ fluent-bit:
     type: es
     es:
       host: elasticsearch-ephemeral
+  parsers:
+    json:
+      - extraEntries: |-
+         Decode_Field_As escaped_utf8 log do_next
+         Decode_Field_As json log
 

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -1,12 +1,12 @@
 # See defaults in https://github.com/helm/charts/tree/master/stable/fluent-bit
 fluent-bit:
+  logLevel: debug
   backend:
     type: es
     es:
       host: elasticsearch-ephemeral
   parsers:
-    json:
-      - extraEntries: |-
-         Decode_Field_As escaped_utf8 log do_next
-         Decode_Field_As json log
-
+    enabled: true
+    regex:
+      - name: nginz
+        regex: '^(?<remote_addr>[^ ]*) (?<remote_user>[^ ]*) "(?<thetime>[0-9\/a-zA-Z:]* [+][0-9]*)" "(?<request>.*)" (?<status>[0-9]*) (?<body_bytes_sent>[0-9]*) "(?<http_referer>[^ ])" "(?<http_user_agent>.*)" (?<http_x_forwarded_for>[^ ]*) (?<connection>[^ ]*) (?<request_time>[0-9.]*) (?<upstream_response_time>[0-9.]*) (?<upstream_cache_status>[^ ]*) (?<zauth_user>[^ ]*) (?<zauth_connection>[^ ]*) (?<request>[a-z0-9]*) (?<optional>[^ ]*)$'

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -1,6 +1,5 @@
 # See defaults in https://github.com/helm/charts/tree/master/stable/fluent-bit
 fluent-bit:
-  logLevel: debug
   backend:
     type: es
     es:
@@ -9,4 +8,4 @@ fluent-bit:
     enabled: true
     regex:
       - name: nginz
-        regex: '^(?<remote_addr>[^ ]*) (?<remote_user>[^ ]*) "(?<thetime>[0-9\/a-zA-Z:]* [+][0-9]*)" "(?<request>.*)" (?<status>[0-9]*) (?<body_bytes_sent>[0-9]*) "(?<http_referer>[^ ])" "(?<http_user_agent>.*)" (?<http_x_forwarded_for>[^ ]*) (?<connection>[^ ]*) (?<request_time>[0-9.]*) (?<upstream_response_time>[0-9.]*) (?<upstream_cache_status>[^ ]*) (?<zauth_user>[^ ]*) (?<zauth_connection>[^ ]*) (?<request>[a-z0-9]*) (?<optional>[^ ]*)$'
+        regex: '^(?<remote_addr>[^ ]*) (?<remote_user>[^ ]*) "(?<thetime>[0-9\/a-zA-Z:]* [+][0-9]*)" "(?<path>.*)" (?<status>[0-9]*) (?<body_bytes_sent>[0-9]*) "(?<http_referer>[^ ])" "(?<http_user_agent>.*)" (?<http_x_forwarded_for>[^ ]*) (?<connection>[^ ]*) (?<request_time>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_cache_status>[^ ]*) (?<zauth_user>[^ ]*) (?<zauth_connection>[^ ]*) (?<request>[a-z0-9]*)'

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
     logLevel: {{ .logLevel }}
+    logFormat: JSON
 
     galley:
       host: 0.0.0.0

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
     logLevel: {{ .logLevel }}
-    logFormat: { .logFormat }}
+    logFormat: {{ .logFormat }}
 
     galley:
       host: 0.0.0.0

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
     logLevel: {{ .logLevel }}
-    logFormat: JSON
+    logFormat: { .logFormat }}
 
     galley:
       host: 0.0.0.0

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -15,6 +15,7 @@ resources:
     cpu: 500m
 config:
   logLevel: Debug
+  logFormat: JSON
   cassandra:
     host: aws-cassandra
     replicaCount: 3

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -14,7 +14,7 @@ resources:
     memory: 512Mi
     cpu: 500m
 config:
-  logLevel: Info
+  logLevel: Debug
   cassandra:
     host: aws-cassandra
     replicaCount: 3

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -14,7 +14,7 @@ resources:
     memory: 512Mi
     cpu: 500m
 config:
-  logLevel: Debug
+  logLevel: Info
   logFormat: JSON
   cassandra:
     host: aws-cassandra

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -52,7 +52,7 @@ http {
   # Logging
   #
 
-  log_format custom_zeta '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" - $connection $request_time $upstream_response_time $upstream_cache_status $zauth_user $zauth_connection $request_id $proxy_protocol_addr';
+  log_format custom_zeta '$remote_addr $remote_user "$time_local" "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $http_x_forwarded_for $connection $request_time $upstream_response_time $upstream_cache_status $zauth_user $zauth_connection $request_id $proxy_protocol_addr';
   access_log /dev/stdout custom_zeta;
 
   #

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        fluentbit.io/parser-nginz: nginz-parser
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }} # should be higher than the drainTimeout (sleep duration of preStop)
       containers:

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
-        fluentbit.io/parser-nginz: nginz-parser
+        fluentbit.io/parser-nginz: nginz
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }} # should be higher than the drainTimeout (sleep duration of preStop)
       containers:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,6 +25,28 @@ Note that since we are not specifying a release name during helm install, it gen
 $ helm install --namespace <namespace> wire/fluent-bit
 ```
 
+## Configuring fluent-bit
+Per pod-template, you can specify what parsers `fluent-bit` needs to use to interpret the pod's logs in a structured way.
+By default, it just parses them as plain text. But, you can change this using a pod annotation. E.g.:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: brig
+  labels:
+    app: brig
+  annotations:
+    fluentbit.io/parser: json
+spec:
+  containers:
+  - name: apache
+    image: edsiper/apache_logs
+```
+
+You can also define your own custom parsers in our `fluent-bit` chart's `values.yml`. For example, we have one defined for `nginz`.
+For more info, see : https://github.com/fluent/fluent-bit-docs/blob/master/filter/kubernetes.md#kubernetes-annotations
+
+
 Alternately, if there is already fluent-bit deployed in your environment, get the helm name for the deployment (verb-noun prepended to the pod name), and
 ```
 $ helm upgrade <helm-name> --namespace <namespace> wire/fluent-bit


### PR DESCRIPTION
also configure fluent-bit to ingest these JSON logs.

Furthermore, we now parse `nginz` logs with structure, which allows us to correlate the `request` of `nginz` with the `request` of `galley` and `brig`



