### PR TITLE
Scrape every 10 seconds

### DIFF
--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -8,7 +8,7 @@ prometheus-operator:
         endpoints:
           - path: '/i/metrics'
             port: http
-            interval: 3m
+            interval: 10s
             metricRelabelings:
               # Rename 'service' to 'role' to allow sharing of grafana dashboards
               # between k8s and AWS services.


### PR DESCRIPTION
Note that the 3m was taken from a different config on our infra, namely the _ec2_sd_configs_ which is a different value and that's just how often to refresh the servers that we need to scrape, not the frequency of the scrape itself