### PR TITLE
Upgrade to latest chart version

### DIFF
--- a/charts/cassandra-ephemeral/requirements.yaml
+++ b/charts/cassandra-ephemeral/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: cassandra
-  version: 0.4.1
+  version: 0.13.3
   repository: https://kubernetes-charts-incubator.storage.googleapis.com
   alias: cassandra-ephemeral

--- a/charts/cassandra-ephemeral/values.yaml
+++ b/charts/cassandra-ephemeral/values.yaml
@@ -1,8 +1,5 @@
 # See defaults in https://github.com/kubernetes/charts/blob/master/incubator/cassandra/values.yaml
 cassandra-ephemeral:
-  image:
-    repo: "cassandra"
-    tag: "3.11.1"
   persistence:
     enabled: false
   resources:


### PR DESCRIPTION
As I was testing things I realised we were using a very old version of the chart, which I was unable to even get to start due to a _very_ short timeout (1s) for the readiness/liveness probes (in production calling `nodetool` takes ~1s :).

Either way, last summer cleaning is always nice IMHO!