### PR TITLE
Feature/simple bootstrap

### DIFF
--- a/ansible/hosts.example-demo.ini
+++ b/ansible/hosts.example-demo.ini
@@ -37,9 +37,9 @@ ansible_python_interpreter = /usr/bin/python3
 ### KUBERNETES section (see kubespray documentation for details) ###
 
 bootstrap_os = ubuntu
-docker_dns_servers_strict = false
+docker_dns_servers_strict = False
 
 [k8s-cluster:vars]
 helm_enabled = True
 kube_network_plugin = flannel
-kubeconfig_localhost = true
+kubeconfig_localhost = True

--- a/ansible/hosts.example-demo.ini
+++ b/ansible/hosts.example-demo.ini
@@ -2,9 +2,8 @@
 
 [all]
 # * 'ansible_host' is the IP to ssh into
-# * 'ip' is the IP to bind to (if multiple network interfaces are in use)
-#   omit 'ip' if you only have one network interface
-kubenode01        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd1
+# * (optional) 'ip' is the IP to bind to (if multiple network interfaces are in use)
+kubenode01    ansible_host=X.X.X.X etcd_member_name=etcd1
 
 [kube-master]
 kubenode01

--- a/bin/bootstrap/README.md
+++ b/bin/bootstrap/README.md
@@ -1,9 +1,15 @@
-# Installing kubernetes on ubuntu
+# Instroduction
+
+This is an experimental easy-to-type bootstrap procedure (from ubuntu to a kubernetes cluster - could be extended, possibly). This downloads a bash script which downloads a docker alternative (since kubespray removes any running docker image during installation), and uses that to run the quay.io/wire/networkless-admin image. Within that image, it creates a host file and uses that to install kubernetes to the host system.
+
+# Status: experimental, may not work for you
+
+# Procedure for installing kubernetes on ubuntu
 
 1. log onto a server running ubuntu
 2. become root: `sudo su -`
 3. Run this init script:
 
 ```
-curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/init.sh > init.sh && chmod +x init.sh && ./init.sh
+curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/develop/bin/bootstrap/init.sh > init.sh && chmod +x init.sh && ./init.sh
 ```

--- a/bin/bootstrap/README.md
+++ b/bin/bootstrap/README.md
@@ -1,0 +1,9 @@
+# Installing kubernetes on ubuntu
+
+1. log onto a server running ubuntu
+2. become root: `sudo su -`
+3. Run this init script:
+
+```
+curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/init.sh > init.sh && chmod +x init.sh && ./init.sh
+```

--- a/bin/bootstrap/init.sh
+++ b/bin/bootstrap/init.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+mkdir -p ../admin_work_dir && cd ../admin_work_dir
+mkdir -p ../dot_ssh
+mkdir -p ../dot_kube
+
+# TODO: if not exists..
+#ssh-keygen -N '' -f /root/.ssh/id_rsa
+#cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+# copy ssh key
+cp ~/.ssh/id_rsa ../dot_ssh/
+
+inside="cp -a /src/* /mnt
+# run ansible from here. If you make any changes, they will be written to your host file system
+# (those files will be owned by root as docker runs as root)
+cd /mnt/wire-server-deploy/ansible
+"
+
+# podman
+sudo apt-get update -qq
+sudo apt-get install -qq -y software-properties-common uidmap
+sudo add-apt-repository -y ppa:projectatomic/ppa
+sudo apt-get update -qq
+sudo apt-get -qq -y install podman
+
+podman run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube  quay.io/wire/networkless-admin

--- a/bin/bootstrap/init.sh
+++ b/bin/bootstrap/init.sh
@@ -4,17 +4,14 @@ mkdir -p ../admin_work_dir && cd ../admin_work_dir
 mkdir -p ../dot_ssh
 mkdir -p ../dot_kube
 
-# TODO: if not exists..
-#ssh-keygen -N '' -f /root/.ssh/id_rsa
-#cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+if [[ ! -f /root/.ssh/id_rsa ]]; then
+    # create ssh key and allow self to ssh in (from a docker image)
+    ssh-keygen -N '' -f /root/.ssh/id_rsa
+    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+fi
+
 # copy ssh key
 cp ~/.ssh/id_rsa ../dot_ssh/
-
-inside="cp -a /src/* /mnt
-# run ansible from here. If you make any changes, they will be written to your host file system
-# (those files will be owned by root as docker runs as root)
-cd /mnt/wire-server-deploy/ansible
-"
 
 # podman
 sudo apt-get update -qq
@@ -22,5 +19,8 @@ sudo apt-get install -qq -y software-properties-common uidmap
 sudo add-apt-repository -y ppa:projectatomic/ppa
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
+
+curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/inside.sh > inside.sh
+chmod +x inside.sh
 
 podman run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube  quay.io/wire/networkless-admin

--- a/bin/bootstrap/init.sh
+++ b/bin/bootstrap/init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+mkdir /opt/admin
+cd /opt/admin
 mkdir -p ../admin_work_dir && cd ../admin_work_dir
 mkdir -p ../dot_ssh
 mkdir -p ../dot_kube

--- a/bin/bootstrap/init.sh
+++ b/bin/bootstrap/init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# See the README.md file next to this script for more information about this script and how it's used.
+
 mkdir /opt/admin
 cd /opt/admin
 mkdir -p ../admin_work_dir && cd ../admin_work_dir
@@ -22,7 +24,7 @@ sudo add-apt-repository -y ppa:projectatomic/ppa
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
 
-curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/inside.sh > inside.sh
+curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/develop/bin/bootstrap/inside.sh > inside.sh
 chmod +x inside.sh
 
 podman run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube --entrypoint /mnt/inside.sh quay.io/wire/networkless-admin

--- a/bin/bootstrap/init.sh
+++ b/bin/bootstrap/init.sh
@@ -25,4 +25,4 @@ sudo apt-get -qq -y install podman
 curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/inside.sh > inside.sh
 chmod +x inside.sh
 
-podman run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube  quay.io/wire/networkless-admin
+podman run -it --network=host -v $(pwd):/mnt -v $(pwd)/../dot_ssh:/root/.ssh -v $(pwd)/../dot_kube:/root/.kube --entrypoint /mnt/inside.sh quay.io/wire/networkless-admin

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 
+set -ex
+
 # When this script is run the first time, copy files over
 if [[ ! -d /mnt/wire-server-deploy ]]; then
-   cp -v -a /src/* /mnt
+   cp -a /src/* /mnt
 fi
 
 # run ansible from here. If you make any changes, they will be written to your host file system
 # (those files will be owned by root as docker runs as root)
 cd /mnt/wire-server-deploy/ansible
 
-
 # This code may be brittle...
 TARGET_IFACE=$(route | grep default | awk '{print $8}')
 TARGET_HOST=$(/sbin/ifconfig $TARGET_IFACE | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 
 if [[ ! -f hosts.ini ]]; then
-   cp hosts.example.ini hosts.ini
+   cp hosts.example-demo.ini hosts.ini
    sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
-   sed -i "s/# docker_dns_servers_strict = false/docker_dns_servers_strict = false/g" hosts.ini
-   sed -i "s/#docker_dns_servers_strict = false/docker_dns_servers_strict = false/g" hosts.ini
 fi
+
+

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -22,3 +22,6 @@ if [[ ! -f hosts.ini ]]; then
 fi
 
 poetry run ansible-playbook -i hosts.ini kubernetes.yml
+
+echo "Great, kubernetes is up! Now follow the directions from:"
+echo "  https://docs.wire.com/how-to/install/helm.html"

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -21,4 +21,4 @@ if [[ ! -f hosts.ini ]]; then
    sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
 fi
 
-poetry run ansible-playbook -i hosts.ini kubernetes.yaml
+poetry run ansible-playbook -i hosts.ini kubernetes.yml

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -13,7 +13,7 @@ cd /mnt/wire-server-deploy/ansible
 
 # This code may be brittle...
 TARGET_IFACE=$(route | grep default | awk '{print $8}')
-TARGET_HOST=$(/sbin/ifconfig $TARGET_IFACE | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+TARGET_HOST=$(/sbin/ifconfig "$TARGET_IFACE" | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 
 if [[ ! -f hosts.ini ]]; then
    curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/ansible/hosts.example-demo.ini > hosts.example-demo.ini
@@ -21,4 +21,4 @@ if [[ ! -f hosts.ini ]]; then
    sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
 fi
 
-
+poetry run ansible-playbook -i hosts.ini kubernetes.yaml

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# See the README.md file next to this script for more information about this script and how it's used.
+
 set -ex
 
 # When this script is run the first time, copy files over
@@ -16,7 +18,7 @@ TARGET_IFACE=$(route | grep default | awk '{print $8}')
 TARGET_HOST=$(/sbin/ifconfig "$TARGET_IFACE" | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 
 if [[ ! -f hosts.ini ]]; then
-   curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/ansible/hosts.example-demo.ini > hosts.example-demo.ini
+   curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/develop/ansible/hosts.example-demo.ini > hosts.example-demo.ini
    cp hosts.example-demo.ini hosts.ini
    sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
 fi

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# When this script is run the first time, copy files over
+if [[ ! -d /mnt/wire-server-deploy ]]; then
+   cp -v -a /src/* /mnt
+fi
+
+# run ansible from here. If you make any changes, they will be written to your host file system
+# (those files will be owned by root as docker runs as root)
+cd /mnt/wire-server-deploy/ansible
+
+
+# This code may be brittle...
+TARGET_IFACE=$(route | grep default | awk '{print $8}')
+TARGET_HOST=$(/sbin/ifconfig $TARGET_IFACE | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+
+if [[ ! -f hosts.ini ]]; then
+   cp hosts.example.ini hosts.ini
+   sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
+   sed -i "s/# docker_dns_servers_strict = false/docker_dns_servers_strict = false/g" hosts.ini
+   sed -i "s/#docker_dns_servers_strict = false/docker_dns_servers_strict = false/g" hosts.ini
+fi

--- a/bin/bootstrap/inside.sh
+++ b/bin/bootstrap/inside.sh
@@ -16,6 +16,7 @@ TARGET_IFACE=$(route | grep default | awk '{print $8}')
 TARGET_HOST=$(/sbin/ifconfig $TARGET_IFACE | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 
 if [[ ! -f hosts.ini ]]; then
+   curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/ansible/hosts.example-demo.ini > hosts.example-demo.ini
    cp hosts.example-demo.ini hosts.ini
    sed -i "s/X.X.X.X/$TARGET_HOST/g" hosts.ini
 fi


### PR DESCRIPTION
Trying things out: a ~~simple~~ easy-to-type bootstrap procedure (from ubuntu to a kubernetes cluster - could be extended, possibly). This downloads a bash script which downloads a docker alternative (since kubespray removes any running docker image during installation), and uses that to run the quay.io/wire/networkless-admin image. Within that image, it creates a host file and uses that to install kubernetes to the host system.

Is this a good approach? A bad approach? Should more work be added here? Or are other alternatives better/faster? Thoughts @tiago-loureiro ?

Precedure:

# Installing kubernetes on ubuntu

1. log onto a server running ubuntu 16.04 or 18.04. Make sure it has at least 4 CPUs and at least 8 GB RAM.
2. become root: `sudo su -`
3. Run this init script:

```
curl -sSfL https://raw.githubusercontent.com/wireapp/wire-server-deploy/feature/simple-bootstrap/bin/bootstrap/init.sh > init.sh && chmod +x init.sh && ./init.sh
```

This should take ~20 minutes and give you a kubernetes installation on that server.
