### PR TITLE
Lower resource requirements and upgrade webapps default versions

### DIFF
--- a/charts/account-pages/values.yaml
+++ b/charts/account-pages/values.yaml
@@ -2,14 +2,14 @@
 replicaCount: 1
 resources:
   requests:
-    memory: 256Mi
-    cpu: "0.5"
+    memory: "128Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
+    memory: "512Mi"
     cpu: "1"
 image:
   repository: quay.io/wire/account
-  tag: 176-0.1.0-a02b4f-v0.20.4-staging
+  tag: 242-2.0.1-c4282e-v0.20.4-production
 service:
   https:
     externalPort: 443

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -7,11 +7,11 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 config:
   logLevel: Info
   cassandra:

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -7,11 +7,11 @@ config:
   logLevel: Info
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 service:
   name: cannon
   internalPort: 8080

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -7,10 +7,10 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 config:
   logLevel: Info

--- a/charts/cassandra-ephemeral/values.yaml
+++ b/charts/cassandra-ephemeral/values.yaml
@@ -4,11 +4,11 @@ cassandra-ephemeral:
     enabled: false
   resources:
     requests:
-      memory: 2.0Gi
-      cpu: 1
+      memory: "2.0Gi"
+      cpu: "1"
     limits:
-      memory: 4.0Gi
-      cpu: 4
+      memory: "4.0Gi"
+      cpu: "4"
   ## Change cassandra configuration paramaters below:
   ## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html
   ## Recommended max heap size is 1/2 of system memory

--- a/charts/elasticsearch-ephemeral/values.yaml
+++ b/charts/elasticsearch-ephemeral/values.yaml
@@ -9,7 +9,7 @@ service:
 resources:
   limits:
     cpu: "2000m"
-    memory: 4Gi
+    memory: "4Gi"
   requests:
-    cpu: "500m"
-    memory: 500Mi
+    cpu: "250m"
+    memory: "500Mi"

--- a/charts/fake-aws-dynamodb/values.yaml
+++ b/charts/fake-aws-dynamodb/values.yaml
@@ -13,7 +13,7 @@ tables:
 resources:
   limits:
     cpu: "300m"
-    memory: 3000Mi
+    memory: "3000Mi"
   requests:
     cpu: "100m"
-    memory: 100Mi
+    memory: "100Mi"

--- a/charts/fake-aws-s3/templates/_helpers.tpl
+++ b/charts/fake-aws-s3/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 53 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 53 chars (63 - len("-discovery")) because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 53 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/fake-aws-sqs/values.yaml
+++ b/charts/fake-aws-sqs/values.yaml
@@ -15,7 +15,7 @@ service:
 resources:
   limits:
     cpu: "1000m"
-    memory: 1000Mi
+    memory: "1000Mi"
   requests:
-    cpu: "500m"
-    memory: 500Mi
+    memory: "256Mi"
+    cpu: "100m"

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -8,11 +8,11 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 config:
   logLevel: Info
   cassandra:

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -7,11 +7,11 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 config:
   logLevel: Info
   cassandra:

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -1,10 +1,10 @@
 replicaCount: 3
 resources:
   requests:
-    memory: 256Mi
-    cpu: "0.5"
+    memory: "256Mi"
+    cpu: "100m"
   limits:
-    memory: 1024Mi
+    memory: "1024Mi"
     cpu: "2"
 images:
   nginzDisco:

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -7,10 +7,10 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: 128Mi
-    cpu: 100m
+    memory: "128Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 config:
   logLevel: Debug

--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -5,8 +5,8 @@ redis-ephemeral:
 
   resources:
     limits:
-      cpu: 1000m
-      memory: 1024Mi
+      cpu: "1000m"
+      memory: "1024Mi"
     requests:
-      cpu: 500m
-      memory: 512Mi
+      cpu: "500m"
+      memory: "512Mi"

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -4,11 +4,11 @@ image:
   tag: 2.62.0
 resources:
   requests:
-    memory: 256Mi
-    cpu: 250m
+    memory: "128Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: "512Mi"
+    cpu: "500m"
 service:
   externalPort: 8080
   internalPort: 8080

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -2,14 +2,14 @@
 replicaCount: 1
 resources:
   requests:
-    memory: 256Mi
-    cpu: "0.5"
+    memory: "128Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
+    memory: "512Mi"
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: 10190-2.7.0-e6d595-v0.20.2-staging
+  tag: 11298-2.9.1-d0536e-v0.23.5-production
 service:
   https:
     externalPort: 443

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -2,14 +2,14 @@
 replicaCount: 1
 resources:
   requests:
-    memory: 256Mi
-    cpu: "0.5"
+    memory: "128Mi"
+    cpu: "100m"
   limits:
-    memory: 512Mi
+    memory: "512Mi"
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 41491-0.1.0-9fe4de-v0.20.2-production
+  tag: 44421-0.1.0-e438dc-v0.24.0-production
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Done on this PR:
 - Lower CPU requirements for many charts: given the default of replica count of 3, ~10% CPU is expected with 10k online users.
 - Standardise on always using double quotes on resources
 - Update webapps to the latest production versions