### PR TITLE
avs-nwtest: implement via jsonnet/kubecfg (WIP)

### DIFF
--- a/kube/README.md
+++ b/kube/README.md
@@ -1,0 +1,42 @@
+Kubecfg/jsonnet-based automation for Wire
+=========================================
+
+TODO(serge): move this to real documentation - this is temporary until it's merged to master
+
+Install kubecfg and jsonnet
+---------------------------
+
+For jsonnet, install it from your package manager.
+
+For kubecfg:
+
+    go get github.com/bitnami/kubecfg
+
+`$GOPATH/bin` must be in your `$PATH`. By default, `$GOPATH` is `$HOME/go/bin`.
+
+Configure your cluster
+----------------------
+
+Once you have a Wire deployment on Kubernetes, you will need to let this automation know about it.
+
+At some point, this will be the one and only step to actually deploy Wire.
+
+For that, edit `deployments.libsonnet`, and add your deployment, basing it on the `example` deployment. See `deployments.libsonnet` for information about configurable fields.
+
+Deploy/update
+-------------
+
+    kubecfg diff --diff-strategy=subset top-kubecfg.jsonnet
+    kubecfg update top-kubecfg.jsonnet
+
+Extra
+-----
+
+We also, as an example, show that the jsonnet codebase can emit more than just kubernetes configs.
+
+For example, we have some machinery for services to declare what nginz routes they want. To view the 'synthesized'
+output of those routes, do:
+
+    jsonnet eval top-nginz.jsonnet
+
+This would be, in practice, consumed by a specialized tool, for instance one that emits nginz configuration (if nginz is not controlled via this codebase, eg. is configured via Helm).

--- a/kube/deployments.libsonnet
+++ b/kube/deployments.libsonnet
@@ -1,0 +1,18 @@
+// This is the main configuration file for your Wire deployment.
+//
+// You can commit it to version control. We aim to not update this file unless necessary,
+// and as such you will likely not have to deal with merge conflicts.
+
+local wire = import "lib/wire.libsonnet";
+
+{
+    // An example deployment. Edit this to match your desired environment.
+    // See clusters.libsonnet for tunables in `cfg`.
+    example: wire.Environment("example") {
+        cfg+: {
+            dns+: {
+                domain: "wire.example.com",
+            },
+        },
+    },
+}

--- a/kube/lib/kube.libsonnet
+++ b/kube/lib/kube.libsonnet
@@ -1,0 +1,712 @@
+// Generic library of Kubernetes objects (https://github.com/bitnami-labs/kube-libsonnet)
+//
+// From: https://github.com/bitnami-labs/kube-libsonnet/blob/master/kube.libsonnet
+// License: Apache License Version 2.0
+//
+// Objects in this file follow the regular Kubernetes API object
+// schema with two exceptions:
+//
+// ## Optional helpers
+//
+// A few objects have defaults or additional "helper" hidden
+// (double-colon) fields that will help with common situations.  For
+// example, `Service.target_pod` generates suitable `selector` and
+// `ports` blocks for the common case of a single-pod/single-port
+// service.  If for some reason you don't want the helper, just
+// provide explicit values for the regular Kubernetes fields that the
+// helper *would* have generated, and the helper logic will be
+// ignored.
+//
+// ## The Underscore Convention:
+//
+// Various constructs in the Kubernetes API use JSON arrays to
+// represent unordered sets or named key/value maps.  This is
+// particularly annoying with jsonnet since we want to use jsonnet's
+// powerful object merge operation with these constructs.
+//
+// To combat this, this library attempts to provide more "jsonnet
+// native" variants of these arrays in alternative hidden fields that
+// end with an underscore.  For example, the `env_` block in
+// `Container`:
+// ```
+// kube.Container("foo") {
+//   env_: { FOO: "bar" },
+// }
+// ```
+// ... produces the expected `container.env` JSON array:
+// ```
+// {
+//   "env": [
+//     { "name": "FOO", "value": "bar" }
+//   ]
+// }
+// ```
+//
+// If you are confused by the underscore versions, or don't want them
+// in your situation then just ignore them and set the regular
+// non-underscore field as usual.
+//
+//
+// ## TODO
+//
+// TODO: Expand this to include all API objects.
+//
+// Should probably fill out all the defaults here too, so jsonnet can
+// reference them.  In addition, jsonnet validation is more useful
+// (client-side, and gives better line information).
+
+{
+  // resource contructors will use kinds/versions/fields compatible at least with version:
+  minKubeVersion: {
+    major: 1,
+    minor: 9,
+    version: "%s.%s" % [self.major, self.minor],
+  },
+
+  // Returns array of values from given object.  Does not include hidden fields.
+  objectValues(o):: [o[field] for field in std.objectFields(o)],
+
+  // Returns array of [key, value] pairs from given object.  Does not include hidden fields.
+  objectItems(o):: [[k, o[k]] for k in std.objectFields(o)],
+
+  // Replace all occurrences of `_` with `-`.
+  hyphenate(s):: std.join("-", std.split(s, "_")),
+
+  // Convert an octal (as a string) to number,
+  parseOctal(s):: (
+    local len = std.length(s);
+    local leading = std.substr(s, 0, len - 1);
+    local last = std.parseInt(std.substr(s, len - 1, 1));
+    assert last < 8 : "found '%s' digit >= 8" % [last];
+    last + (if len > 1 then 8 * $.parseOctal(leading) else 0)
+  ),
+
+  // Convert {foo: {a: b}} to [{name: foo, a: b}]
+  mapToNamedList(o):: [{ name: $.hyphenate(n) } + o[n] for n in std.objectFields(o)],
+
+  // Return object containing only these fields elements
+  filterMapByFields(o, fields): { [field]: o[field] for field in std.setInter(std.objectFields(o), fields) },
+
+  // Convert from SI unit suffixes to regular number
+  siToNum(n):: (
+    local convert =
+      if std.endsWith(n, "m") then [1, 0.001]
+      else if std.endsWith(n, "K") then [1, 1e3]
+      else if std.endsWith(n, "M") then [1, 1e6]
+      else if std.endsWith(n, "G") then [1, 1e9]
+      else if std.endsWith(n, "T") then [1, 1e12]
+      else if std.endsWith(n, "P") then [1, 1e15]
+      else if std.endsWith(n, "E") then [1, 1e18]
+      else if std.endsWith(n, "Ki") then [2, std.pow(2, 10)]
+      else if std.endsWith(n, "Mi") then [2, std.pow(2, 20)]
+      else if std.endsWith(n, "Gi") then [2, std.pow(2, 30)]
+      else if std.endsWith(n, "Ti") then [2, std.pow(2, 40)]
+      else if std.endsWith(n, "Pi") then [2, std.pow(2, 50)]
+      else if std.endsWith(n, "Ei") then [2, std.pow(2, 60)]
+      else error "Unknown numerical suffix in " + n;
+    local n_len = std.length(n);
+    std.parseInt(std.substr(n, 0, n_len - convert[0])) * convert[1]
+  ),
+
+  local remap(v, start, end, newstart) =
+    if v >= start && v <= end then v - start + newstart else v,
+  local remapChar(c, start, end, newstart) =
+    std.char(remap(
+      std.codepoint(c), std.codepoint(start), std.codepoint(end), std.codepoint(newstart)
+    )),
+  toLower(s):: (
+    std.join("", [remapChar(c, "A", "Z", "a") for c in std.stringChars(s)])
+  ),
+  toUpper(s):: (
+    std.join("", [remapChar(c, "a", "z", "A") for c in std.stringChars(s)])
+  ),
+
+  _Object(apiVersion, kind, name):: {
+    local this = self,
+    apiVersion: apiVersion,
+    kind: kind,
+    metadata: {
+      name: name,
+      labels: { name: std.join("-", std.split(this.metadata.name, ":")) },
+      annotations: {},
+    },
+  },
+
+  List(): {
+    apiVersion: "v1",
+    kind: "List",
+    items_:: {},
+    items: $.objectValues(self.items_),
+  },
+
+  Namespace(name): $._Object("v1", "Namespace", name) {
+  },
+
+  Endpoints(name): $._Object("v1", "Endpoints", name) {
+    Ip(addr):: { ip: addr },
+    Port(p):: { port: p },
+
+    subsets: [],
+  },
+
+  Service(name): $._Object("v1", "Service", name) {
+    local service = self,
+
+    target_pod:: error "service target_pod required",
+    port:: self.target_pod.spec.containers[0].ports[0].containerPort,
+
+    // Helpers that format host:port in various ways
+    host:: "%s.%s.svc" % [self.metadata.name, self.metadata.namespace],
+    host_colon_port:: "%s:%s" % [self.host, self.spec.ports[0].port],
+    http_url:: "http://%s/" % self.host_colon_port,
+    proxy_urlpath:: "/api/v1/proxy/namespaces/%s/services/%s/" % [
+      self.metadata.namespace,
+      self.metadata.name,
+    ],
+    // Useful in Ingress rules
+    name_port:: {
+      serviceName: service.metadata.name,
+      servicePort: service.spec.ports[0].port,
+    },
+
+    spec: {
+      selector: service.target_pod.metadata.labels,
+      ports: [
+        {
+          port: service.port,
+          targetPort: service.target_pod.spec.containers[0].ports[0].containerPort,
+        },
+      ],
+      type: "ClusterIP",
+    },
+  },
+
+  PersistentVolume(name): $._Object("v1", "PersistentVolume", name) {
+    spec: {},
+  },
+
+  // TODO: This is a terrible name
+  PersistentVolumeClaimVolume(pvc): {
+    persistentVolumeClaim: { claimName: pvc.metadata.name },
+  },
+
+  StorageClass(name): $._Object("storage.k8s.io/v1beta1", "StorageClass", name) {
+    provisioner: error "provisioner required",
+  },
+
+  PersistentVolumeClaim(name): $._Object("v1", "PersistentVolumeClaim", name) {
+    local pvc = self,
+
+    storageClass:: null,
+    storage:: error "storage required",
+
+    metadata+: if pvc.storageClass != null then {
+      annotations+: {
+        "volume.beta.kubernetes.io/storage-class": pvc.storageClass,
+      },
+    } else {},
+
+    spec: {
+      resources: {
+        requests: {
+          storage: pvc.storage,
+        },
+      },
+      accessModes: ["ReadWriteOnce"],
+      [if pvc.storageClass != null then "storageClassName"]: pvc.storageClass,
+    },
+  },
+
+  Container(name): {
+    name: name,
+    image: error "container image value required",
+    imagePullPolicy: if std.endsWith(self.image, ":latest") then "Always" else "IfNotPresent",
+
+    envList(map):: [
+      if std.type(map[x]) == "object" then { name: x, valueFrom: map[x] } else { name: x, value: map[x] }
+      for x in std.objectFields(map)
+    ],
+
+    env_:: {},
+    env: self.envList(self.env_),
+
+    args_:: {},
+    args: ["--%s=%s" % kv for kv in $.objectItems(self.args_)],
+
+    ports_:: {},
+    ports: $.mapToNamedList(self.ports_),
+
+    volumeMounts_:: {},
+    volumeMounts: $.mapToNamedList(self.volumeMounts_),
+
+    stdin: false,
+    tty: false,
+    assert !self.tty || self.stdin : "tty=true requires stdin=true",
+  },
+
+  PodDisruptionBudget(name): $._Object("policy/v1beta1", "PodDisruptionBudget", name) {
+    local this = self,
+    target_pod:: error "target_pod required",
+    spec: {
+      minAvailable: 1,
+      selector: {
+        matchLabels: this.target_pod.metadata.labels,
+      },
+    },
+  },
+
+  Pod(name): $._Object("v1", "Pod", name) {
+    spec: $.PodSpec,
+  },
+
+  PodSpec: {
+    // The 'first' container is used in various defaults in k8s.
+    local container_names = std.objectFields(self.containers_),
+    default_container:: if std.length(container_names) > 1 then "default" else container_names[0],
+    containers_:: {},
+
+    local container_names_ordered = [self.default_container] + [n for n in container_names if n != self.default_container],
+    containers: [{ name: $.hyphenate(name) } + self.containers_[name] for name in container_names_ordered if self.containers_[name] != null],
+
+    // Note initContainers are inherently ordered, and using this
+    // named object will lose that ordering.  If order matters, then
+    // manipulate `initContainers` directly (perhaps
+    // appending/prepending to `super.initContainers` to mix+match
+    // both approaches)
+    initContainers_:: {},
+    initContainers: [{ name: $.hyphenate(name) } + self.initContainers_[name] for name in std.objectFields(self.initContainers_) if self.initContainers_[name] != null],
+
+    volumes_:: {},
+    volumes: $.mapToNamedList(self.volumes_),
+
+    imagePullSecrets: [],
+
+    terminationGracePeriodSeconds: 30,
+
+    assert std.length(self.containers) > 0 : "must have at least one container",
+
+    // Return an array of pod's ports numbers
+    ports(proto):: [
+      p.containerPort
+      for p in std.flattenArrays([
+        c.ports
+        for c in self.containers
+      ])
+      if (
+        (!(std.objectHas(p, "protocol")) && proto == "TCP")
+        ||
+        ((std.objectHas(p, "protocol")) && p.protocol == proto)
+      )
+    ],
+
+  },
+
+  EmptyDirVolume(): {
+    emptyDir: {},
+  },
+
+  HostPathVolume(path, type=""): {
+    hostPath: { path: path, type: type },
+  },
+
+  GitRepoVolume(repository, revision): {
+    gitRepo: {
+      repository: repository,
+
+      // "master" is possible, but should be avoided for production
+      revision: revision,
+    },
+  },
+
+  SecretVolume(secret): {
+    secret: { secretName: secret.metadata.name },
+  },
+
+  ConfigMapVolume(configmap): {
+    configMap: { name: configmap.metadata.name },
+  },
+
+  ConfigMap(name): $._Object("v1", "ConfigMap", name) {
+    data: {},
+
+    // I keep thinking data values can be any JSON type.  This check
+    // will remind me that they must be strings :(
+    local nonstrings = [
+      k
+      for k in std.objectFields(self.data)
+      if std.type(self.data[k]) != "string"
+    ],
+    assert std.length(nonstrings) == 0 : "data contains non-string values: %s" % [nonstrings],
+  },
+
+  // subtype of EnvVarSource
+  ConfigMapRef(configmap, key): {
+    assert std.objectHas(configmap.data, key) : "%s not in configmap.data" % [key],
+    configMapKeyRef: {
+      name: configmap.metadata.name,
+      key: key,
+    },
+  },
+
+  Secret(name): $._Object("v1", "Secret", name) {
+    local secret = self,
+
+    type: "Opaque",
+    data_:: {},
+    data: { [k]: std.base64(secret.data_[k]) for k in std.objectFields(secret.data_) },
+  },
+
+  // subtype of EnvVarSource
+  SecretKeyRef(secret, key): {
+    assert std.objectHas(secret.data, key) : "%s not in secret.data" % [key],
+    secretKeyRef: {
+      name: secret.metadata.name,
+      key: key,
+    },
+  },
+
+  // subtype of EnvVarSource
+  FieldRef(key): {
+    fieldRef: {
+      apiVersion: "v1",
+      fieldPath: key,
+    },
+  },
+
+  // subtype of EnvVarSource
+  ResourceFieldRef(key, divisor="1"): {
+    resourceFieldRef: {
+      resource: key,
+      divisor: std.toString(divisor),
+    },
+  },
+
+  Deployment(name): $._Object("apps/v1", "Deployment", name) {
+    local deployment = self,
+
+    spec: {
+      template: {
+        spec: $.PodSpec,
+        metadata: {
+          labels: deployment.metadata.labels,
+          annotations: {},
+        },
+      },
+
+      selector: {
+        matchLabels: deployment.spec.template.metadata.labels,
+      },
+
+      strategy: {
+        type: "RollingUpdate",
+
+        local pvcs = [
+          v
+          for v in deployment.spec.template.spec.volumes
+          if std.objectHas(v, "persistentVolumeClaim")
+        ],
+        local is_stateless = std.length(pvcs) == 0,
+
+        // Apps trying to maintain a majority quorum or similar will
+        // want to tune these carefully.
+        // NB: Upstream default is surge=1 unavail=1
+        rollingUpdate: if is_stateless then {
+          maxSurge: "25%",  // rounds up
+          maxUnavailable: "25%",  // rounds down
+        } else {
+          // Poor-man's StatelessSet.  Useful mostly with replicas=1.
+          maxSurge: 0,
+          maxUnavailable: 1,
+        },
+      },
+
+      // NB: Upstream default is 0
+      minReadySeconds: 30,
+
+      // NB: Regular k8s default is to keep all revisions
+      revisionHistoryLimit: 10,
+
+      replicas: 1,
+    },
+  },
+
+  CrossVersionObjectReference(target): {
+    apiVersion: target.apiVersion,
+    kind: target.kind,
+    name: target.metadata.name,
+  },
+
+  HorizontalPodAutoscaler(name): $._Object("autoscaling/v1", "HorizontalPodAutoscaler", name) {
+    local hpa = self,
+
+    target:: error "target required",
+
+    spec: {
+      scaleTargetRef: $.CrossVersionObjectReference(hpa.target),
+
+      minReplicas: hpa.target.spec.replicas,
+      maxReplicas: error "maxReplicas required",
+
+      assert self.maxReplicas >= self.minReplicas,
+    },
+  },
+
+  StatefulSet(name): $._Object("apps/v1", "StatefulSet", name) {
+    local sset = self,
+
+    spec: {
+      serviceName: name,
+
+      updateStrategy: {
+        type: "RollingUpdate",
+        rollingUpdate: {
+          partition: 0,
+        },
+      },
+
+      template: {
+        spec: $.PodSpec,
+        metadata: {
+          labels: sset.metadata.labels,
+          annotations: {},
+        },
+      },
+
+      selector: {
+        matchLabels: sset.spec.template.metadata.labels,
+      },
+
+      volumeClaimTemplates_:: {},
+      volumeClaimTemplates: [
+        // StatefulSet is overly fussy about "changes" (even when
+        // they're no-ops).
+        // In particular annotations={} is apparently a "change",
+        // since the comparison is ignorant of defaults.
+        std.prune($.PersistentVolumeClaim($.hyphenate(kv[0])) + { apiVersion:: null, kind:: null } + kv[1])
+        for kv in $.objectItems(self.volumeClaimTemplates_)
+      ],
+
+      replicas: 1,
+      assert self.replicas >= 1,
+    },
+  },
+
+  Job(name): $._Object("batch/v1", "Job", name) {
+    local job = self,
+
+    spec: $.JobSpec {
+      template+: {
+        metadata+: {
+          labels: job.metadata.labels,
+        },
+      },
+    },
+  },
+
+  // NB: kubernetes >= 1.8.x has batch/v1beta1 (olders were batch/v2alpha1)
+  CronJob(name): $._Object("batch/v1beta1", "CronJob", name) {
+    local cronjob = self,
+
+    spec: {
+      jobTemplate: {
+        spec: $.JobSpec {
+          template+: {
+            metadata+: {
+              labels: cronjob.metadata.labels,
+            },
+          },
+        },
+      },
+
+      schedule: error "Need to provide spec.schedule",
+      successfulJobsHistoryLimit: 10,
+      failedJobsHistoryLimit: 20,
+      // NB: upstream concurrencyPolicy default is "Allow"
+      concurrencyPolicy: "Forbid",
+    },
+  },
+
+  JobSpec: {
+    local this = self,
+
+    template: {
+      spec: $.PodSpec {
+        restartPolicy: "OnFailure",
+      },
+    },
+
+    completions: 1,
+    parallelism: 1,
+  },
+
+  DaemonSet(name): $._Object("apps/v1", "DaemonSet", name) {
+    local ds = self,
+    spec: {
+      updateStrategy: {
+        type: "RollingUpdate",
+        rollingUpdate: {
+          maxUnavailable: 1,
+        },
+      },
+      template: {
+        metadata: {
+          labels: ds.metadata.labels,
+          annotations: {},
+        },
+        spec: $.PodSpec,
+      },
+
+      selector: {
+        matchLabels: ds.spec.template.metadata.labels,
+      },
+    },
+  },
+
+  Ingress(name): $._Object("extensions/v1beta1", "Ingress", name) {
+    spec: {},
+
+    local rel_paths = [
+      p.path
+      for r in self.spec.rules
+      for p in r.http.paths
+      if !std.startsWith(p.path, "/")
+    ],
+    assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
+  },
+
+  ThirdPartyResource(name): $._Object("extensions/v1beta1", "ThirdPartyResource", name) {
+    versions_:: [],
+    versions: [{ name: n } for n in self.versions_],
+  },
+
+  CustomResourceDefinition(group, version, kind): {
+    local this = self,
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata+: {
+      name: this.spec.names.plural + "." + this.spec.group,
+    },
+    spec: {
+      scope: "Namespaced",
+      group: group,
+      version: version,
+      names: {
+        kind: kind,
+        singular: $.toLower(self.kind),
+        plural: self.singular + "s",
+        listKind: self.kind + "List",
+      },
+    },
+  },
+
+  ServiceAccount(name): $._Object("v1", "ServiceAccount", name) {
+  },
+
+  Role(name): $._Object("rbac.authorization.k8s.io/v1beta1", "Role", name) {
+    rules: [],
+  },
+
+  ClusterRole(name): $.Role(name) {
+    kind: "ClusterRole",
+  },
+
+  Group(name): {
+    kind: "Group",
+    name: name,
+    apiGroup: "rbac.authorization.k8s.io",
+  },
+
+  User(name): {
+    kind: "User",
+    name: name,
+    apiGroup: "rbac.authorization.k8s.io",
+  },
+
+  RoleBinding(name): $._Object("rbac.authorization.k8s.io/v1beta1", "RoleBinding", name) {
+    local rb = self,
+
+    subjects_:: [],
+    subjects: [{
+      kind: o.kind,
+      namespace: o.metadata.namespace,
+      name: o.metadata.name,
+    } for o in self.subjects_],
+
+    roleRef_:: error "roleRef is required",
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: rb.roleRef_.kind,
+      name: rb.roleRef_.metadata.name,
+    },
+  },
+
+  ClusterRoleBinding(name): $.RoleBinding(name) {
+    kind: "ClusterRoleBinding",
+  },
+
+  // NB: datalines_ can be used to reduce boilerplate importstr as:
+  // kubectl get secret ... -ojson mysec | kubeseal | jq -r .spec.data > mysec-ssdata.txt
+  //   datalines_: importstr "mysec-ssddata.txt"
+  SealedSecret(name): $._Object("bitnami.com/v1alpha1", "SealedSecret", name) {
+    spec: {
+      data:
+        if self.datalines_ != ""
+        then std.join("", std.split(self.datalines_, "\n"))
+        else error "data or datalines_ required (output from: kubeseal | jq -r .spec.data)",
+      datalines_:: "",
+    },
+    assert std.base64Decode(self.spec.data) != "",
+  },
+
+  // NB: helper method to access several Kubernetes objects podRef,
+  // used below to extract its labels
+  podRef(obj):: ({
+                   Pod: obj,
+                   Deployment: obj.spec.template,
+                   StatefulSet: obj.spec.template,
+                   DaemonSet: obj.spec.template,
+                   Job: obj.spec.template,
+                   CronJob: obj.spec.jobTemplate.spec.template,
+                 }[obj.kind]),
+
+  // NB: return a { podSelector: ... } ready to use for e.g. NSPs (see below)
+  // pod labels can be optionally filtered by their label name 2nd array arg
+  podLabelsSelector(obj, filter=null):: {
+    podSelector: std.prune({
+      matchLabels:
+        if filter != null then $.filterMapByFields($.podRef(obj).metadata.labels, filter)
+        else $.podRef(obj).metadata.labels,
+    }),
+  },
+
+  // NB: Returns an array as [{ port: num, protocol: "PROTO" }, {...}, ... ]
+  // Need to split TCP, UDP logic to be able to dedup each set of protocol ports
+  podsPorts(obj_list):: std.flattenArrays([
+    [
+      { port: port, protocol: protocol }
+      for port in std.set(
+        std.flattenArrays([$.podRef(obj).spec.ports(protocol) for obj in obj_list])
+      )
+    ]
+    for protocol in ["TCP", "UDP"]
+  ]),
+
+  // NB: most of the "helper" stuff comes from above (podLabelsSelector, podsPorts),
+  // NetworkPolicy returned object will have "Ingress", "Egress" policyTypes auto-set
+  // based on populated spec.ingress or spec.egress
+  // See tests/test-simple-validate.jsonnet for example(s).
+  NetworkPolicy(name): $._Object("networking.k8s.io/v1", "NetworkPolicy", name) {
+    local networkpolicy = self,
+    spec: {
+      policyTypes: std.prune([
+        if networkpolicy.spec.ingress != [] then "Ingress" else null,
+        if networkpolicy.spec.egress != [] then "Egress" else null,
+      ]),
+      ingress: $.objectValues(self.ingress_),
+      ingress_:: {},
+      egress: $.objectValues(self.egress_),
+      egress_:: {},
+      podSelector: {},
+    },
+  },
+}

--- a/kube/lib/wire.libsonnet
+++ b/kube/lib/wire.libsonnet
@@ -1,0 +1,181 @@
+local kube = import "kube.libsonnet";
+
+// Wire deployment.
+
+{
+    local wire = self,
+
+    // A Wire Environment. Also called a Deployment.
+    // Contains all services/components required to run Wire on k8s, apart from
+    // per-cluster services.
+    // All components will be run in a given k8s namespace, by default named
+    // after the environment.
+    Environment(name):: {
+        local env = self,
+        local cfg = env.cfg,
+
+        // User configurable.
+        cfg:: {
+            // Name of environment, used internally. Can be overridden.
+            name: name,
+            // Kubernetes namespace in which environment will be run. Can be overridden.
+            namespace: name,
+
+            // Public DNS names to be used by wire-server.
+            dns: {
+                // Top-level domain. Must be set, or all specific domain names
+                // underneath must be overriden.
+                domain: error "dns.domain must be set", // .my-wire.example.com
+
+                // Default DNS prefixes for top-level domain.
+                nginzHTTPS: "nginz-https.%s" % [cfg.dns.domain],
+                nginzTLS: "nginz-tls.%s" % [cfg.dns.domain],
+                webapp: "webapp.%s" % [cfg.dns.domain],
+                assets: "assets.%s" % [cfg.dns.domain],
+                account: "account.%s" % [cfg.dns.domain],
+                teams: "teams.%s" % [cfg.dns.domain],
+            },
+
+            // Images and versions of components.
+            images: {
+                avsNetworkTestTool: "quay.io/wire/avs-nwtesttool:1.0.12",
+            },
+        },
+
+        // Intermediary component configurations.
+        components:: wire.blueprints(env),
+
+        // Outputted to top-level files.
+        outputs: {
+            // To kubecfg.
+            kubernetes: {
+                namespace: kube.Namespace(cfg.namespace),
+
+                components: {
+                    [c]: env.components[c].kubernetes
+                    for c in std.objectFields(env.components)
+                },
+            },
+
+            // To sample nginz rule generator.
+            nginz: {
+                rules: std.flattenArrays([
+                    [
+                        {
+                            local component = env.components[c],
+                            rule: n.route,
+                            target: {
+                                host: component.kubernetes.service.host,
+                                port: n.port,
+                            },
+                        },
+                        for n in env.components[c].nginz
+                    ]
+                    for c in std.objectFields(env.components)
+                ]),
+            }
+        },
+    },
+
+    // A Wire Component.
+    // A Wire Component is a microservice that lives within an Environment.
+    // These correspond to wire-server services.
+    // Non wire-server services should likely define and use a different type.
+    Component(name, env):: {
+        local component = self,
+        local cfg = component.cfg,
+
+        name:: name,
+
+        // One or more containers run as part of this component.
+        // These must be of type kube.Container.
+        container:: error "container(s) must be set!",
+        containers:: [ component.container ],
+
+        // Nginz rules incoming into this component.
+        nginz:: {
+            // { port: 8080, route: "/foo/bar" },
+        },
+
+        kubernetes: {
+            local k8s = self,
+            metadata:: {
+                namespace: env.cfg.namespace,
+            },
+
+            deployment: kube.Deployment(name) {
+                metadata+: k8s.metadata,
+
+                spec+: {
+                    template+: {
+                        spec+: {
+                            containers: component.containers,
+                            serviceAccountName: k8s.account.metadata.name,
+                        },
+                    },
+                },
+            },
+
+            service: kube.Service(name) {
+                metadata+: k8s.metadata,
+                target_pod:: k8s.deployment.spec.template,
+                spec+: {
+                    ports: [
+                        { name: "nginz-%d" % [p.port], port: p.port, targetPort: p.port, protocol: "TCP" },
+                        for p in component.nginz
+                    ],
+                }
+            },
+
+            account: kube.ServiceAccount(name) {
+                metadata+: k8s.metadata,
+                automountServiceAccountToken: false,
+            },
+        },
+    },
+
+    // Wrapper around kube.Container that gives us some nice defaults.
+    Container(name): kube.Container(name) {
+        resources: {
+            local resources = self,
+            requests: {
+                memory: "64Mi",
+                cpu: "100m",
+            },
+
+            limits: {
+                // By default, set limits to twice the requests.
+                memory: std.toString(kube.siToNum(resources.requests.memory) * 2),
+                cpu: std.toString(kube.siToNum(resources.requests.cpu) * 2),
+            },
+        }
+    },
+
+    // All components required to run wire-server.
+    blueprints(env):: {
+        // AVS Network Test Tool.
+        // Provides a self-rendered web view to run tests against TURN servers
+        // in a given backend.
+        AVSNetworkTestTool: wire.Component("avs-nwtesttool", env) {
+            local component = self,
+
+            container:: wire.Container("main") {
+                image: env.cfg.images.avsNetworkTestTool,
+                env_: {
+                    // Public URL of Backend (not internal service!).
+                    BACKEND_HTTPS_URL: "https://%s/" % [env.cfg.dns.nginzHTTPS],
+                },
+                // Args not needed. By default, container serves on port 80.
+            },
+
+            nginz: [
+                { port: 80, route: "/calls/test" },
+            ],
+        },
+    },
+
+    asserts:: [
+        // Old versions of jsonnet/kubecfg do not implement std.find.
+        if !std.hasObject(std, "find") then error "please upgrade jsonnet/kubecfg" else null,
+    ],
+}

--- a/kube/top-all.jsonnet
+++ b/kube/top-all.jsonnet
@@ -1,0 +1,2 @@
+local deployments = import "deployments.libsonnet";
+

--- a/kube/top-kubecfg.jsonnet
+++ b/kube/top-kubecfg.jsonnet
@@ -1,0 +1,6 @@
+local deployments = import "deployments.libsonnet";
+
+{
+    [d]: deployments[d].outputs.kubernetes
+    for d in std.objectFields(deployments)
+}

--- a/kube/top-nginz.jsonnet
+++ b/kube/top-nginz.jsonnet
@@ -1,0 +1,6 @@
+local deployments = import "deployments.libsonnet";
+
+{
+    [d]: deployments[d].outputs.nginz
+    for d in std.objectFields(deployments)
+}


### PR DESCRIPTION
This implements the deployment of the AVS Network Test Tool (avs-nwtesttool).

To make it a bit more interesting, we deploy it using kubecfg/jsonnet instead of using Helm.

For that, we pull in `kube.libsonnet` from bitnami, and write a small framework that is composed of:
 - wire deployments/environments
   (we call them deployment at the top-level configs, but environments deepr within jsonnet machinery to not confuse them with Kubernetes Deployments)
 - wire components
   (eg. microservices composed usually of a deployment+service that is exposed via nginz - this is a paradigm that can be extended in the future)

We not only export kubernetes-consumable objects from the jsonnet config, but also nginz routes as an example of multiple outputs from a single configuration.

This is all currently documented in a small README.md, which will be turned into real documentation once this PR stabilizes.

Fixes https://github.com/zinfra/backend-issues/issues/892