### PR TITLE
*: unify DNS names for demo deployments

### DIFF
--- a/ansible/roles/minio-static-files/defaults/main.yml
+++ b/ansible/roles/minio-static-files/defaults/main.yml
@@ -6,7 +6,7 @@
 #domain: example.com
 #deeplink_title: Example Environment
 
-assetsURL: "https://{{ prefix }}s3.{{ domain }}"
+assetsURL: "https://{{ prefix }}assets.{{ domain }}"
 deeplink_config_json: "{{ assetsURL }}/public/deeplink.json"
 backendURL: "https://{{ prefix }}https.{{ domain }}"
 backendWSURL: "https://{{ prefix }}ssl.{{ domain }}"

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -39,13 +39,13 @@ service:
 # You will need to supply some DNS names, namely
 # config:
 #   dns:
-#     https: bare-https.<domain>
-#     ssl: bare-ssl.<domain>
-#     webapp: bare-webapp.<domain>
-#     fakeS3: bare-s3.<domain>
-#     teamSettings: bare-team.<domain>
+#     https: nginz-https.<domain>
+#     ssl: nginz-ssl.<domain>
+#     webapp: webapp.<domain>
+#     fakeS3: s3.<domain>
+#     teamSettings: teams.<domain>
 #     ^ teamSettings is ignored unless teamSettings.enabled == true
-#     accountPages: bare-account.<domain>
+#     accountPages: account.<domain>
 #     ^ accountPages is ignored unless accountPages.enabled == true
 # For TLS
 # secrets:

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -42,7 +42,7 @@ service:
 #     https: nginz-https.<domain>
 #     ssl: nginz-ssl.<domain>
 #     webapp: webapp.<domain>
-#     fakeS3: s3.<domain>
+#     fakeS3: assets.<domain>
 #     teamSettings: teams.<domain>
 #     ^ teamSettings is ignored unless teamSettings.enabled == true
 #     accountPages: account.<domain>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,11 +78,12 @@ In case you're unfamiliar with the [helm documentation](https://docs.helm.sh/)
 
 * A kubernetes node with a _public_ IP address (or internal, if you do not plan to expose the Wire backend over the Internet but we will assume you are using a public IP address)
 * DNS records for the different exposed addresses (the ingress depends on the usage of virtual hosts), namely:
-  * bare-https.your-domain
-  * bare-ssl.your-domain
-  * bare-s3.your-domain
-  * bare-webapp.your-domain
-  * bare-team.your-domain (optional)
+  * nginz-https.your-domain
+  * nginz-ssl.your-domain
+  * s3.your-domain
+  * webapp.your-domain
+  * teams.your-domain (optional)
+  * account.your-domain (optional)
 * A wildcard certificate for the different hosts (*.your-domain) - we assume you want to do SSL termination on the ingress controller
 
 **Caveats**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ In case you're unfamiliar with the [helm documentation](https://docs.helm.sh/)
 * DNS records for the different exposed addresses (the ingress depends on the usage of virtual hosts), namely:
   * nginz-https.your-domain
   * nginz-ssl.your-domain
-  * s3.your-domain
+  * assets.your-domain
   * webapp.your-domain
   * teams.your-domain (optional)
   * account.your-domain (optional)

--- a/values/nginx-ingress-services/demo-values.example.yaml
+++ b/values/nginx-ingress-services/demo-values.example.yaml
@@ -11,6 +11,6 @@ config:
     https: nginz-https.example.com
     ssl: nginz-ssl.example.com
     webapp: webapp.example.com
-    fakeS3: s3.example.com
+    fakeS3: assets.example.com
     teamSettings: team.example.com
     accountPages: account.example.com

--- a/values/nginx-ingress-services/prod-values.example.yaml
+++ b/values/nginx-ingress-services/prod-values.example.yaml
@@ -12,7 +12,7 @@ config:
     https: nginz-https.example.com
     ssl: nginz-ssl.example.com
     webapp: webapp.example.com
-    fakeS3: s3.example.com
+    fakeS3: assets.example.com
     teamSettings: team.example.com
     accountPages: account.example.com
 

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -69,7 +69,7 @@ cargohold:
       # change if using real AWS
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
-      s3DownloadEndpoint: https://s3.example.com
+      s3DownloadEndpoint: https://assets.example.com
 
 galley:
   replicaCount: 1

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -69,7 +69,7 @@ cargohold:
       # change if using real AWS
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
-      s3DownloadEndpoint: https://bare-s3.example.com
+      s3DownloadEndpoint: https://s3.example.com
 
 galley:
   replicaCount: 1
@@ -122,10 +122,10 @@ webapp:
   #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
-      backendRest: bare-https.example.com
-      backendWebsocket: bare-ssl.example.com
+      backendRest: nginz-https.example.com
+      backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
-      appHost: bare-webapp.example.com
+      appHost: webapp.example.com
 
 team-settings:
   replicaCount: 1
@@ -133,10 +133,10 @@ team-settings:
   #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
-      backendRest: bare-https.example.com
-      backendWebsocket: bare-ssl.example.com
+      backendRest: nginz-https.example.com
+      backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
-      appHost: bare-webapp.example.com
+      appHost: webapp.example.com
 
 account-pages:
   replicaCount: 1
@@ -144,6 +144,6 @@ account-pages:
   #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
-      backendRest: bare-https.example.com
+      backendRest: nginz-https.example.com
       backendDomain: example.com
-      appHost: bare-webapp.example.com
+      appHost: webapp.example.com

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -84,7 +84,7 @@ cargohold:
       # change if using real AWS
       s3Bucket: assets
       s3Endpoint: http://minio-external:9000
-      s3DownloadEndpoint: https://s3.example.com
+      s3DownloadEndpoint: https://assets.example.com
 
 galley:
   replicaCount: 3


### PR DESCRIPTION
This change unifies the list of domains that users should set up to the
following list of canonical prefixes:

 - `nginz-https.<domain>`
 - `nginx-ssl.<domain>`
 - `webapp.<domain>`
 - `s3.<domain>`
 - `teams.<domain>` (optional)
 - `account.<domain>` (optional)

Naturally, following this scheme is not a hard requirement, and users can
change these as they please. However, keeping them in sync allows for
users to do a blind search/replace from `example.com` to their domain,
without having to immediately understand the roles of different
subdomains.

Optimally we would have all of these defined in a single source of truth
file that would be sourced from all Helm charts, but I'm not sure this
is something that we can easily do.