### PR TITLE
Separate etcd from k8s nodes & moves them into dedicated machines

### DIFF
--- a/ansible/download_kubespray.yml
+++ b/ansible/download_kubespray.yml
@@ -1,4 +1,6 @@
 # download a specific version of kubespray
+# Note: installing it via ansible-galaxy would re-arranges its content (roles/etcd is misplaced)
+#       the reason for this behaviour is yet to be known
 # Usage: see Makefile
 - name: download kubespray
   hosts: localhost
@@ -9,7 +11,7 @@
     # uses
     # kube_version = "v1.14.2"
     # helm_version = "v2.13.1"
-    # (if needed, these can be overridding in the hosts.ini under the [k8s-cluster:vars] section)
+    # (if needed, these can be overridden in the hosts.ini under the [k8s-cluster:vars] section)
     # also see download_cli_binaries.yml to see client-side versions of `kubectl` and `helm`.
     kubespray_version: e2f5a9748e4dbfe2fdba7931198b0b5f1f4bdc7e
   tasks:

--- a/ansible/download_kubespray.yml
+++ b/ansible/download_kubespray.yml
@@ -1,5 +1,5 @@
 # download a specific version of kubespray
-# Note: installing it via ansible-galaxy would re-arranges its content (roles/etcd is misplaced)
+# Note: installing it via ansible-galaxy would re-arrange its content (roles/etcd is misplaced)
 #       the reason for this behaviour is yet to be known
 # Usage: see Makefile
 - name: download kubespray

--- a/ansible/hosts.example.ini
+++ b/ansible/hosts.example.ini
@@ -21,10 +21,15 @@ restund02         ansible_host=X.X.X.X
 # * 'ip' is the IP to bind to (if multiple network interfaces are in use)
 #   omit 'ip' if you only have one network interface
 #   FIXME: note that kubespray has a test for if IP == ANSIBLE_HOST?
+kubenode01        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+kubenode02        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+kubenode03        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+
+# etcd resides on dedicated machines
 # * etcd_member_name needs to be set on all hosts that run etcd (and must be different)
-kubenode01        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd1
-kubenode02        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd2
-kubenode03        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd3
+etcd01            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd1
+etcd02            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd2
+etcd03            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd3
 
 ### databases ###
 
@@ -81,9 +86,9 @@ kubenode03
 # must be an odd number of servers! (playbooks will fail otherwise)
 # See https://coreos.com/etcd/docs/latest/v2/admin_guide.html#optimal-cluster-size
 [etcd]
-kubenode01
-kubenode02
-kubenode03
+etcd01
+etcd02
+etcd03
 
 [kube-node]
 kubenode01

--- a/terraform/examples/inventory.tpl
+++ b/terraform/examples/inventory.tpl
@@ -1,5 +1,6 @@
 [all]
 ${connection_strings_node}
+${connection_strings_etcd}
 ${connection_strings_minio}
 ${connection_strings_elasticsearch}
 ${connection_strings_cassandra}


### PR DESCRIPTION
* before, control-plane + etcd + workload were sitting in the same machines,
  but this does not reflect the current architectural design as described
  in the docs (e.g. https://docs.wire.com/how-to/install/planning.html#implementation-planl)
  This change aims to apply the described design to TF example
* fixes some typos
* states a note on why kubespray is not installed as a role through
  requirements.yml