### PR TITLE
Updated docs and use example.com everywhere

### DIFF
--- a/charts/account-pages/values.yaml
+++ b/charts/account-pages/values.yaml
@@ -33,6 +33,8 @@ envVars: {}
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
 #   You are likely to need at least following CSP headers
+#   due to the fact that you are likely to do cross sub-domain requests
+#   i.e., from account.example.com to nginz-https.example.com
 #   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
 #   CSP_EXTRA_IMG_SRC: "https://*.example.com"
 #   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"

--- a/charts/account-pages/values.yaml
+++ b/charts/account-pages/values.yaml
@@ -20,9 +20,9 @@ service:
 
 #config:
 #  externalUrls:
-#   backendRest: <nginz-subdomain-https.your.domain>
-#   backendDomain: <your.domain>
-#   appHost: <account-pages-subdomain.your.domain>
+#   backendRest: nginz-https.example.com
+#   backendWebsocket: nginz-ssl.example.com
+#   appHost: account.example.com
 #
 # Some relevant environment options, have a look at
 # https://github.com/wireapp/wire-account/wiki/Self-hosting
@@ -32,4 +32,16 @@ envVars: {}
 # E.g.
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
-#
+#   You are likely to need at least following CSP headers
+#   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
+#   CSP_EXTRA_IMG_SRC: "https://*.example.com"
+#   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"
+#   CSP_EXTRA_DEFAULT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FONT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FRAME_SRC: "https://*.example.com"
+#   CSP_EXTRA_MANIFEST_SRC: "https://*.example.com"
+#   CSP_EXTRA_OBJECT_SRC: "https://*.example.com"
+#   CSP_EXTRA_MEDIA_SRC: "https://*.example.com"
+#   CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
+#   CSP_EXTRA_STYLE_SRC: "https://*.example.com"
+#   CSP_EXTRA_WORKER_SRC: "https://*.example.com"

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -39,6 +39,8 @@ envVars: {}
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
 #   You are likely to need at least following CSP headers
+#   due to the fact that you are likely to do cross sub-domain requests
+#   i.e., from teams.example.com to nginz-https.example.com
 #   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
 #   CSP_EXTRA_IMG_SRC: "https://*.example.com"
 #   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -20,10 +20,10 @@ service:
 
 #config:
 #  externalUrls:
-#   backendRest: <nginz-subdomain-https.your.domain>
-#   backendWebsocket: <nginz-subdomain-ssl.your.domain>
-#   backendDomain: <your.domain>
-#   appHost: <team-settings-subdomain.your.domain>
+#   backendRest: nginz-https.example.com
+#   backendWebsocket: nginz-ssl.example.com
+#   backendDomain: example.com
+#   appHost: teams.example.com
 
 #secrets:
 #   configJson: <secret-to-be-asked-from-wire>
@@ -38,4 +38,16 @@ envVars: {}
 # E.g.
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
-#
+#   You are likely to need at least following CSP headers
+#   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
+#   CSP_EXTRA_IMG_SRC: "https://*.example.com"
+#   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"
+#   CSP_EXTRA_DEFAULT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FONT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FRAME_SRC: "https://*.example.com"
+#   CSP_EXTRA_MANIFEST_SRC: "https://*.example.com"
+#   CSP_EXTRA_OBJECT_SRC: "https://*.example.com"
+#   CSP_EXTRA_MEDIA_SRC: "https://*.example.com"
+#   CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
+#   CSP_EXTRA_STYLE_SRC: "https://*.example.com"
+#   CSP_EXTRA_WORKER_SRC: "https://*.example.com"

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,10 +20,10 @@ service:
 
 #config:
 #  externalUrls:
-#   backendRest: <nginz-subdomain-https.your.domain>
-#   backendWebsocket: <nginz-subdomain-ssl.your.domain>
-#   backendDomain: <your.domain>
-#   appHost: <webapp-subdomain.your.domain>
+#   backendRest: nginz-https.example.com
+#   backendWebsocket: nginz-ssl.example.com
+#   backendDomain: example.com
+#   appHost: webapp.example.com
 
 # Some relevant environment options, have a look at
 # https://github.com/wireapp/wire-webapp/wiki/Self-hosting
@@ -33,4 +33,16 @@ envVars: {}
 # E.g.
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
-#
+#   You are likely to need at least following CSP headers
+#   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
+#   CSP_EXTRA_IMG_SRC: "https://*.example.com"
+#   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"
+#   CSP_EXTRA_DEFAULT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FONT_SRC: "https://*.example.com"
+#   CSP_EXTRA_FRAME_SRC: "https://*.example.com"
+#   CSP_EXTRA_MANIFEST_SRC: "https://*.example.com"
+#   CSP_EXTRA_OBJECT_SRC: "https://*.example.com"
+#   CSP_EXTRA_MEDIA_SRC: "https://*.example.com"
+#   CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
+#   CSP_EXTRA_STYLE_SRC: "https://*.example.com"
+#   CSP_EXTRA_WORKER_SRC: "https://*.example.com"

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -34,6 +34,8 @@ envVars: {}
 # envVars:
 #   FEATURE_ENABLE_DEBUG: "true"
 #   You are likely to need at least following CSP headers
+#   due to the fact that you are likely to do cross sub-domain requests
+#   i.e., from webapp.example.com to nginz-https.example.com
 #   CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
 #   CSP_EXTRA_IMG_SRC: "https://*.example.com"
 #   CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"


### PR DESCRIPTION
Standardise on using example.com everywhere and update the values.yaml file with a comment about CSP headers which is often forgotten and a cause of webapps misbehaving