### PR TITLE
Fix cannon's StatefulSetSpec causing ValidationError for podManagementPolicy

### DIFF
--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:
@@ -29,7 +30,6 @@ spec:
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      podManagementPolicy: Parallel
       terminationGracePeriodSeconds: {{ .Values.drainTimeout }} # should be higher than the sleep duration of preStop
       containers:
       - name: cannon


### PR DESCRIPTION
Docs [1] say `podManagementPolicy` must be part of the StatefulSetSpec, but atm it's
part of the PodSpec within the pod template of the StatefulSet. This causes helm v3 to
throw a `ValidationError(StatefulSet.spec.template.spec): unknown field "podManagementPolicy" in io.k8s.api.core.v1.PodSpec`
See following issue for some more context [2].

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#statefulset-v1-apps
[2] https://github.com/wireapp/wire-docs/issues/21