### PR TITLE
Fix setting heap size for ES

### DIFF
--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -4,9 +4,7 @@
   vars:
     # The following sets java heap size to 1GB (default is 2GB)
     # comment that line when deploying on machines with >= 4GB memory.
-    es_jvm_custom_parameters:
-      - "-Xmx1g"
-      - "-Xms1g"
+    es_heap_size: "1g"
 
     es_enable_xpack: false
     es_xpack_features: [] # disable features


### PR DESCRIPTION
Looking at: https://github.com/elastic/ansible-elasticsearch/blob/d145d188e9ddabb27c40df8635cdbdd45cc4eeb6/templates/jvm.options.j2

we see that if we define `es_jvm_custom_parameters` and no `es_heap_size` we end up, in the config file, with:
```
...
-Xms2g
-Xmx2g
...
-Xms1g
-Xmx1g
```