### PR TITLE
Add team-id to brig-index

### DIFF
--- a/charts/elasticsearch-index/templates/configmap.yaml
+++ b/charts/elasticsearch-index/templates/configmap.yaml
@@ -52,7 +52,8 @@ data:
                      "name"       : { "type": "keyword", "index": false },
                      "handle"     : { "type": "text"                    },
                      "accent_id"  : { "type": "byte",    "index": false },
-                     "suspended"  : { "type": "integer"                 }
+                     "suspended"  : { "type": "integer"                 },
+                     "team_id"    : { "type": "keyword"                 }
                  }
             }
 


### PR DESCRIPTION
This is required because #189 and wireapp/wire-server#964 won't pass the tests
without each other. This commit should be mergeable without any changes in
wire-server and it will also make wire-server changes mergeable, which in turn
will let tests pass with #189.

Fixes zinfra/backend-issues#1142