### PR TITLE
Add missing routes to spar

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -320,10 +320,28 @@ nginx_conf:
     - path: /sso-initiate-bind
       envs:
       - all
+    - path: /sso/initiate-login
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
+    - path: /sso/finalize-login
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
     - path: /sso
       envs:
       - all
       disable_zauth: true
+    - path: /scim/v2
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
+    - path: /scim
+      envs:
+      - all
     proxy:
     - path: /proxy
       envs:


### PR DESCRIPTION
Currently trying to generate SCIM tokens will result in:
```
open() "/etc/nginx/html/scim/auth-tokens" failed (2: No such file or directory)
```