### PR TITLE
Release_2020_03_02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
-# NEXT
+# 2020-03-02
 
-## Important
+## Breaking changes / known issues when upgrading
 
 - upgrading an existing Helm release of `wire-server` needs to be enforced (i.e. `--force`) or done by reinstalling it
 
 ## Features
 
 - enable Helm v3 support
+- Helm charts:
+  - nginz: Expose internal sso settings and custom backends (#178, #191)
+  - brig: New option setUserMaxPermClients is now available for brig (#185)
+  - cannon: comply with K8s StatefulSetSpec (#187)
 
-## Bug fixes
+## Other updates
 
-- changed cannon template to comply with K8s StatefulSetSpec [#187](https://github.com/wireapp/wire-server-deploy/pull/187)
+- Skip flaky test in brig-integration (#184)
+- Ansible: fix mc policy set (#181) - thanks @kvaps
+- Ansible: Fix setting heap size for ES (#188)
 
 
 # 2020-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# NEXT
+
+## Important
+
+- upgrading an existing Helm release of `wire-server` needs to be enforced (i.e. `--force`) or done by reinstalling it
+
+## Features
+
+- enable Helm v3 support
+
+## Bug fixes
+
+- changed cannon template to comply with K8s StatefulSetSpec [#187](https://github.com/wireapp/wire-server-deploy/pull/187)
+
+
 # 2020-01-09
 
 ## Features

--- a/ansible/download_kubespray.yml
+++ b/ansible/download_kubespray.yml
@@ -1,4 +1,6 @@
 # download a specific version of kubespray
+# Note: installing it via ansible-galaxy would re-arrange its content (roles/etcd is misplaced)
+#       the reason for this behaviour is yet to be known
 # Usage: see Makefile
 - name: download kubespray
   hosts: localhost
@@ -9,7 +11,7 @@
     # uses
     # kube_version = "v1.14.2"
     # helm_version = "v2.13.1"
-    # (if needed, these can be overridding in the hosts.ini under the [k8s-cluster:vars] section)
+    # (if needed, these can be overridden in the hosts.ini under the [k8s-cluster:vars] section)
     # also see download_cli_binaries.yml to see client-side versions of `kubectl` and `helm`.
     kubespray_version: e2f5a9748e4dbfe2fdba7931198b0b5f1f4bdc7e
   tasks:

--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -4,9 +4,7 @@
   vars:
     # The following sets java heap size to 1GB (default is 2GB)
     # comment that line when deploying on machines with >= 4GB memory.
-    es_jvm_custom_parameters:
-      - "-Xmx1g"
-      - "-Xms1g"
+    es_heap_size: "1g"
 
     es_enable_xpack: false
     es_xpack_features: [] # disable features

--- a/ansible/hosts.example.ini
+++ b/ansible/hosts.example.ini
@@ -21,10 +21,15 @@ restund02         ansible_host=X.X.X.X
 # * 'ip' is the IP to bind to (if multiple network interfaces are in use)
 #   omit 'ip' if you only have one network interface
 #   FIXME: note that kubespray has a test for if IP == ANSIBLE_HOST?
+kubenode01        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+kubenode02        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+kubenode03        ansible_host=X.X.X.X ip=Y.Y.Y.Y
+
+# etcd resides on dedicated machines
 # * etcd_member_name needs to be set on all hosts that run etcd (and must be different)
-kubenode01        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd1
-kubenode02        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd2
-kubenode03        ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd3
+etcd01            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd1
+etcd02            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd2
+etcd03            ansible_host=X.X.X.X ip=Y.Y.Y.Y etcd_member_name=etcd3
 
 ### databases ###
 
@@ -81,9 +86,9 @@ kubenode03
 # must be an odd number of servers! (playbooks will fail otherwise)
 # See https://coreos.com/etcd/docs/latest/v2/admin_guide.html#optimal-cluster-size
 [etcd]
-kubenode01
-kubenode02
-kubenode03
+etcd01
+etcd02
+etcd03
 
 [kube-node]
 kubenode01

--- a/ansible/minio.yml
+++ b/ansible/minio.yml
@@ -60,7 +60,7 @@
       tags: mc-config
 
     - name: "make the 'public' bucket world-accessible"
-      shell: "mc policy public local/public"
+      shell: "mc policy set public local/public"
       run_once: true
       tags: mc-config
 

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -182,5 +182,8 @@ data:
       {{- if .setSearchSameTeamOnly }}
       setSearchSameTeamOnly: {{ .setSearchSameTeamOnly }}
       {{- end }}
+      {{- if .setUserMaxPermClients }}
+      setUserMaxPermClients: {{ .setUserMaxPermClients }}
+      {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -51,7 +51,9 @@ spec:
     # to get certain behaviour. This doesn't work on kubernetes because brig
     # is a different pod than brig-integration and they can't both mouht the
     # same file-system.
-    command: ["brig-integration", "--pattern", "!/turn/"]
+    # The other test, "user.auth.cookies.limit", is skipped as it is flaky.
+    # This is tracked in https://github.com/zinfra/backend-issues/issues/1150.
+    command: ["brig-integration", "--pattern", "!/turn/ && !/user.auth.cookies.limit/"]
     volumeMounts:
     - name: "brig-integration"
       mountPath: "/etc/wire/integration"

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -69,6 +69,8 @@ config:
     setDeleteThrottleMillis: 100
     # Allow search within same team only. Default: false
     # setSearchSameTeamOnly: false|true
+    # Set max number of user clients. Default: 7
+    # setUserMaxPermClients: <int>
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
 turnStatic:

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:
@@ -29,7 +30,6 @@ spec:
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      podManagementPolicy: Parallel
       terminationGracePeriodSeconds: {{ .Values.drainTimeout }} # should be higher than the sleep duration of preStop
       containers:
       - name: cannon

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -320,10 +320,28 @@ nginx_conf:
     - path: /sso-initiate-bind
       envs:
       - all
+    - path: /sso/initiate-login
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
+    - path: /sso/finalize-login
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
     - path: /sso
       envs:
       - all
       disable_zauth: true
+    - path: /scim/v2
+      envs:
+      - all
+      disable_zauth: true
+      allow_credentials: true
+    - path: /scim
+      envs:
+      - all
     proxy:
     - path: /proxy
       envs:

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -280,6 +280,15 @@ nginx_conf:
       - staging
       disable_zauth: true
       basic_auth: true
+    - path: ~* ^/custom-backend/by-domain/([^/]*)$
+      zauth: false
+      envs:
+      - all
+    - path: ~* ^/i/custom-backend/by-domain/([^/]*)$
+      zauth: false
+      basic_auth: true
+      envs:
+      - staging
     - path: ~* ^/teams/api-docs
       envs:
       - all
@@ -303,6 +312,11 @@ nginx_conf:
       max_body_size: 256k
       envs:
       - all
+    - path: /i/sso
+      disable_zauth: true
+      basic_auth: true
+      envs:
+      - staging
     - path: /sso-initiate-bind
       envs:
       - all

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -281,11 +281,11 @@ nginx_conf:
       disable_zauth: true
       basic_auth: true
     - path: ~* ^/custom-backend/by-domain/([^/]*)$
-      zauth: false
+      disable_zauth: true
       envs:
       - all
     - path: ~* ^/i/custom-backend/by-domain/([^/]*)$
-      zauth: false
+      disable_zauth: true
       basic_auth: true
       envs:
       - staging

--- a/terraform/examples/inventory.tpl
+++ b/terraform/examples/inventory.tpl
@@ -1,5 +1,6 @@
 [all]
 ${connection_strings_node}
+${connection_strings_etcd}
 ${connection_strings_minio}
 ${connection_strings_elasticsearch}
 ${connection_strings_cassandra}


### PR DESCRIPTION
## Breaking changes / known issues when upgrading

- upgrading an existing Helm release of `wire-server` needs to be enforced (i.e. `--force`) or done by reinstalling it

## Features

- enable Helm v3 support
- Helm charts:
  - nginz: Expose internal sso settings and custom backends (#178, #191)
  - brig: New option setUserMaxPermClients is now available for brig (#185)
  - cannon: comply with K8s StatefulSetSpec (#187)

## Other updates

- Skip flaky test in brig-integration (#184)
- Ansible: fix mc policy set (#181) - thanks @kvaps
- Ansible: Fix setting heap size for ES (#188)