### PR TITLE
Bump ingress-controller dep to prevent failing helm-upgrade after initial install

### DIFF
--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 1.11.3
+  version: 1.33.3
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
The issue was discovered by @tiago-loureiro while rerunning `helm upgrade nginx-ingress-controller` + helm v3 to bootstrap with https://github.com/wireapp/wire-server-deploy-networkless/pull/25

for more information, see https://github.com/helm/charts/pull/20518 