### PR TITLE
Release_2020_03_06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2020-03-06
+
+## Bug fixes
+
+- fix an issue where rerunning `helm upgrade nginx-ingress-controller` (w/o any change) might fail as
+  described in https://github.com/helm/charts/pull/20518 (#194)
+
 # 2020-03-02
 
 ## Breaking changes / known issues when upgrading

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 1.11.3
+  version: 1.33.3
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
## Bug fixes

- fix an issue where rerunning `helm upgrade nginx-ingress-controller` (w/o any change) might fail as described in https://github.com/helm/charts/pull/20518 (#194)