### PR TITLE
Fix elasticsearch-external endpoint

### DIFF
--- a/charts/elasticsearch-external/templates/endpoint.yaml
+++ b/charts/elasticsearch-external/templates/endpoint.yaml
@@ -32,4 +32,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - port: {{ .Values.portHttp }}
+      # port and name in the endpoint must match port and name in the service
+      # see also https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html
+      - name: http
+        port: {{ .Values.portHttp }}


### PR DESCRIPTION
We forgot this chart when fixing the endpoints [here](https://github.com/wireapp/wire-server-deploy/pull/7)