### PR TITLE
Use apps/v1 for all deployments

### DIFF
--- a/charts/account-pages/Chart.yaml
+++ b/charts/account-pages/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire account pages in Kubernetes
 name: account-pages
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/account-pages/templates/deployment.yaml
+++ b/charts/account-pages/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: account-pages

--- a/charts/backoffice/Chart.yaml
+++ b/charts/backoffice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Backoffice tool
 name: backoffice
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/backoffice/templates/deployment.yaml
+++ b/charts/backoffice/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backoffice

--- a/charts/brig/Chart.yaml
+++ b/charts/brig/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Brig (part of Wire Server) - User management
 name: brig
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: brig

--- a/charts/cargohold/Chart.yaml
+++ b/charts/cargohold/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Cargohold (part of Wire Server) - Asset storage
 name: cargohold
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cargohold

--- a/charts/elasticsearch-ephemeral/Chart.yaml
+++ b/charts/elasticsearch-ephemeral/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral elasticsearch
 name: elasticsearch-ephemeral
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        component: {{ template "fullname" . }}
     metadata:
       labels:
         component: {{ template "fullname" . }}

--- a/charts/fake-aws-dynamodb/Chart.yaml
+++ b/charts/fake-aws-dynamodb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral DynamoDB service
 name: fake-aws-dynamodb
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        app: {{ template "fullname" . }}
     metadata:
       labels:
         app: {{ template "fullname" . }}

--- a/charts/fake-aws-ses/Chart.yaml
+++ b/charts/fake-aws-ses/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SES service (based on localstack)
 name: fake-aws-ses
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/fake-aws-ses/templates/deployment.yaml
+++ b/charts/fake-aws-ses/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/charts/fake-aws-ses/templates/deployment.yaml
+++ b/charts/fake-aws-ses/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        app: {{ template "fullname" . }}
     metadata:
       labels:
         app: {{ template "fullname" . }}

--- a/charts/fake-aws-sns/Chart.yaml
+++ b/charts/fake-aws-sns/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SNS service (based on localstack)
 name: fake-aws-sns
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/fake-aws-sns/templates/deployment.yaml
+++ b/charts/fake-aws-sns/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/charts/fake-aws-sns/templates/deployment.yaml
+++ b/charts/fake-aws-sns/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        app: {{ template "fullname" . }}
     metadata:
       labels:
         app: {{ template "fullname" . }}

--- a/charts/fake-aws-sqs/Chart.yaml
+++ b/charts/fake-aws-sqs/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Dummy ephemeral SQS service
 name: fake-aws-sqs
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/fake-aws-sqs/templates/deployment.yaml
+++ b/charts/fake-aws-sqs/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/charts/fake-aws-sqs/templates/deployment.yaml
+++ b/charts/fake-aws-sqs/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        app: {{ template "fullname" . }}
     metadata:
       labels:
         app: {{ template "fullname" . }}

--- a/charts/galley/Chart.yaml
+++ b/charts/galley/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Galley (part of Wire Server) - Conversations
 name: galley
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: galley

--- a/charts/gundeck/Chart.yaml
+++ b/charts/gundeck/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Gundeck (part of Wire Server) - Push Notification Hub Service
 name: gundeck
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gundeck

--- a/charts/nginz/Chart.yaml
+++ b/charts/nginz/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for nginz in Kubernetes
 name: nginz
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginz

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Proxy (part of Wire Server) - 3rd party proxy service
 name: proxy
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.89.0
+version: 0.89.0-pr.200
 name: reaper
 appVersion: 0.1.0
 description: A helm charts to restart cannons if redis-ephemeal has died

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   replicas: 1
   template:
+    selector:
+      matchLabels:
+        wireService: reaper
+        release: {{ .Release.Name }}
     metadata:
       labels:
         wireService: reaper

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reaper

--- a/charts/spar/Chart.yaml
+++ b/charts/spar/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Spar (part of Wire Server) - SSO Service
 name: spar
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spar

--- a/charts/team-settings/Chart.yaml
+++ b/charts/team-settings/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire team-settings in Kubernetes
 name: team-settings
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/team-settings/templates/deployment.yaml
+++ b/charts/team-settings/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: team-settings

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.89.0
+version: 0.89.0-pr.200

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp


### PR DESCRIPTION
These are all the cases I found. But I haven't tested this on a 1.16 cluster as I don't have one yet. 

We need to still make sure that all the helm charts we depend on are also compatible with K8s 1.16. Easiest way would be to try to deploy to K8s 1.16 and run the tests.

Fixes zinfra/backend-issues#1210