### PR TITLE
Release 2020 03 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2020-03-25
+
+## Features
+
+- `calling-test` chart using the wire-nwtesttool (#204)
+
+## Internal changes
+
+- Move hardcoded AWS_REGION env var value into chart values file (#197) - thanks @kvaps
+- Use apps/v1 for all deployments (#201)
+- Fix elasticsearch-external endpoint (#198)
+- Minor improvements to consistency with naming and settings.
+
 # 2020-03-06
 
 ## Bug fixes

--- a/ansible/roles/minio-static-files/defaults/main.yml
+++ b/ansible/roles/minio-static-files/defaults/main.yml
@@ -10,7 +10,7 @@ assetsURL: "https://{{ prefix }}assets.{{ domain }}"
 deeplink_config_json: "{{ assetsURL }}/public/deeplink.json"
 backendURL: "https://{{ prefix }}https.{{ domain }}"
 backendWSURL: "https://{{ prefix }}ssl.{{ domain }}"
-teamsURL: "https://{{ prefix }}team.{{ domain }}"
+teamsURL: "https://{{ prefix }}teams.{{ domain }}"
 accountsURL: "https://{{ prefix }}account.{{ domain }}"
 
 # FUTUREWORK:

--- a/charts/account-pages/templates/deployment.yaml
+++ b/charts/account-pages/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: account-pages

--- a/charts/backoffice/templates/deployment.yaml
+++ b/charts/backoffice/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backoffice

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
                 key: awsSecretKey
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
-            value: "eu-west-1"
+            value: "{{ .Values.config.aws.region }}"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: brig

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -61,7 +61,6 @@ config:
       retryAfter: 86400
     setRichInfoLimit: 5000
     setDefaultLocale: en
-    setMaxConvAndTeamSize: 500
     setMaxTeamSize: 500
     setMaxConvSize: 500
     setEmailVisibility: visible_to_self

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -22,6 +22,7 @@ config:
     port: 9200
     index: directory
   aws:
+    region: "eu-west-1"
     sesEndpoint: https://email.eu-west-1.amazonaws.com
     sqsEndpoint: https://sqs.eu-west-1.amazonaws.com
     dynamoDBEndpoint: https://dynamodb.eu-west-1.amazonaws.com

--- a/charts/calling-test/.helmignore
+++ b/charts/calling-test/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/calling-test/Chart.yaml
+++ b/charts/calling-test/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: calling-test
+description: Network testing tool for audio/video/signalling. See https://github.com/wireapp/avs-nwtesttool for more details.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.0.14

--- a/charts/calling-test/templates/NOTES.txt
+++ b/charts/calling-test/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Get the application URL by running these commands:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "calling-test.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:8080

--- a/charts/calling-test/templates/_helpers.tpl
+++ b/charts/calling-test/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "calling-test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "calling-test.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "calling-test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "calling-test.labels" -}}
+helm.sh/chart: {{ include "calling-test.chart" . }}
+{{ include "calling-test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "calling-test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "calling-test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/calling-test/templates/deployment.yaml
+++ b/charts/calling-test/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "calling-test.fullname" . }}
+  labels:
+    {{- include "calling-test.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "calling-test.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "calling-test.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+        {{- range $key, $val := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+        {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/calling-test/templates/service.yaml
+++ b/charts/calling-test/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "calling-test.fullname" . }}
+  labels:
+    {{- include "calling-test.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "calling-test.selectorLabels" . | nindent 4 }}

--- a/charts/calling-test/values.yaml
+++ b/charts/calling-test/values.yaml
@@ -1,0 +1,27 @@
+replicaCount: 1
+image:
+  # note: the docker image tag is configured as 'appVersion' in Chart.yaml
+  repository: quay.io/wire/avs-nwtesttool
+  pullPolicy: IfNotPresent
+
+envVars:
+  # note: this should be overridden in every deployment
+  BACKEND_HTTPS_URL: https://nginz-https.example.com
+
+# These name overrides are used also for routing.
+# Wire-server's nginz subchart will route /calling-test to this chart
+# If you change this name, that functionality will break.
+nameOverride: "calling-test"
+fullnameOverride: "calling-test"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cargohold

--- a/charts/demo-smtp/templates/deployment.yaml
+++ b/charts/demo-smtp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "demo-smtp.fullname" . }}

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -11,6 +11,9 @@ metadata:
     component: {{ template "fullname" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/elasticsearch-external/templates/endpoint.yaml
+++ b/charts/elasticsearch-external/templates/endpoint.yaml
@@ -32,4 +32,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - port: {{ .Values.portHttp }}
+      # port and name in the endpoint must match port and name in the service
+      # see also https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html
+      - name: http
+        port: {{ .Values.portHttp }}

--- a/charts/fake-aws-dynamodb/templates/deployment.yaml
+++ b/charts/fake-aws-dynamodb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/fake-aws-ses/templates/deployment.yaml
+++ b/charts/fake-aws-ses/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/fake-aws-sns/templates/deployment.yaml
+++ b/charts/fake-aws-sns/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/fake-aws-sqs/templates/deployment.yaml
+++ b/charts/fake-aws-sqs/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                 name: galley
                 key: awsSecretKey
           - name: AWS_REGION
-            value: eu-west-1
+            value: "{{ .Values.config.aws.region }}"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: galley

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -20,7 +20,6 @@ config:
     host: aws-cassandra
     replicaCount: 3
   settings:
-    maxConvAndTeamSize: 500
     maxTeamSize: 500
     maxConvSize: 500
     featureFlags:  # see #RefConfigOptions in `/docs/reference` (https://github.com/wireapp/wire-server/)

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -26,3 +26,5 @@ config:
     featureFlags:  # see #RefConfigOptions in `/docs/reference` (https://github.com/wireapp/wire-server/)
       sso: disabled-by-default
       legalhold: disabled-by-default
+  aws:
+    region: "eu-west-1"

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                 name: gundeck
                 key: awsSecretKey
           - name: AWS_REGION
-            value: "eu-west-1"
+            value: "{{ .Values.config.aws.region }}"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gundeck

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -20,3 +20,5 @@ config:
     host: redis-ephemeral
     port: 6379
   bulkPush: false
+  aws:
+    region: "eu-west-1"

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginz

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -361,3 +361,8 @@ nginx_conf:
     - path: ~* ^/teams/([^/]*)/billing(.*)
       envs:
       - all
+    calling-test:
+    - path: /calling-test
+      envs:
+      - all
+      disable_zauth: true

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reaper
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      wireService: reaper
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spar

--- a/charts/team-settings/templates/deployment.yaml
+++ b/charts/team-settings/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: team-settings

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp

--- a/values/wire-server/prod-secrets.example.yaml
+++ b/values/wire-server/prod-secrets.example.yaml
@@ -67,8 +67,3 @@ team-settings:
   secrets:
     # Required if you want to use team-settings
     configJson:
-
-account-pages:
-  secrets:
-    # Required if you want to use account-pages
-    configJson:


### PR DESCRIPTION
Does not include the latest ES index changes, as those should only be released here once on master on wire-server.

# 2020-03-25

## Features

- `calling-test` chart using the wire-nwtesttool (#204)

## Internal changes

- Move hardcoded AWS_REGION env var value into chart values file (#197) - thanks @kvaps
- Use apps/v1 for all deployments (#201)
- Fix elasticsearch-external endpoint (#198)
- Minor improvements to consistency with naming and settings.