### PR TITLE
Remove ansible-java role here

### DIFF
--- a/ansible/cassandra.yml
+++ b/ansible/cassandra.yml
@@ -15,10 +15,6 @@
       tags:
         - ntp
 
-    - role: ansible-role-java
-      tags:
-        - java
-
     - role: ansible-cassandra
       tags:
         - cassandra


### PR DESCRIPTION
This role is already called in ansible-cassandra https://github.com/wireapp/ansible-cassandra/blob/0fe61f9e4a6dac04e483b9b53708529912413a00/molecule/default/playbook.yml and specifies a specific version, which is what we want to be doing here