### PR TITLE
Add brig index migrations

### DIFF
--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -29,10 +29,10 @@ spec:
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
       restartPolicy: OnFailure
-      containers:
+      initContainers:
         # Creates index in elasticsearch only when it doesn't exist.
         # Does nothing if the index exists.
-        - name: brig-index
+        - name: brig-index-create
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
             - create
@@ -43,3 +43,12 @@ spec:
             - --elasticsearch-shards=5
             - --elasticsearch-replicas=2
             - --elasticsearch-refresh-interval=5
+      containers:
+        - name: brig-index-update-mapping
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          args:
+            - update-mapping
+            - --elasticsearch-server
+            - "http://{{ required "missing elasticsearch-index.elasticsearch.host!" .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}"
+            - --elasticsearch-index
+            - "{{ .Values.elasticsearch.index }}"

--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -8,15 +8,12 @@ metadata:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
-{{- if .Values.hook.enabled }}
   annotations:
     # when hook.enabled=true (default), this chart does not work standalone, but is intended as
     # either a 'post'-subchart to an elasticsearch chart or a 'pre'-subchart to wire-server
     # For the meaning of hooks, see https://docs.helm.sh/developing_charts/#hooks
-    "helm.sh/hook": {{ .Values.hook.type }}-install,{{ .Values.hook.type }}-upgrade
-    "helm.sh/hook-weight": "10" # ensure this runs after elasticsearch-index configmap
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
 spec:
   template:
     metadata:

--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -9,9 +9,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
-    # when hook.enabled=true (default), this chart does not work standalone, but is intended as
-    # either a 'post'-subchart to an elasticsearch chart or a 'pre'-subchart to wire-server
-    # For the meaning of hooks, see https://docs.helm.sh/developing_charts/#hooks
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:

--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: elasticsearch-index
+  name: elasticsearch-index-create
   labels:
-    wireService: elasticsearch-index
-    app: elasticsearch-index
+    wireService: elasticsearch-index-create
+    app: elasticsearch-index-create
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
@@ -16,8 +16,8 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        wireService: elasticsearch-index
-        app: elasticsearch-index
+        wireService: elasticsearch-index-create
+        app: elasticsearch-index-create
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"

--- a/charts/elasticsearch-index/templates/migrate-data.yaml
+++ b/charts/elasticsearch-index/templates/migrate-data.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: brig-index-migrate-data
+  labels:
+    wireService: elasticsearch-index-migrate-data
+    app: elasticsearch-index-migrate-data
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        wireService: elasticsearch-index-migrate-data
+        app: elasticsearch-index-migrate-data
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        # Creates index in elasticsearch only when it doesn't exist.
+        # Does nothing if the index exists.
+        - name: brig-index
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          args:
+            - migrate-data
+            - --elasticsearch-server
+            - "http://{{ required "missing elasticsearch-index.elasticsearch.host!" .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}"
+            - --elasticsearch-index
+            - "{{ .Values.elasticsearch.index }}"
+            - --cassandra-host
+            - "{{ required "missing elasticsearch-index.cassandra.host!" .Values.cassandra.host }}"
+            - --cassandra-port
+            - "{{ required "missing elasticsearch-index.cassandra.port!" .Values.cassandra.port }}"
+            - --cassandra-keyspace
+            - "{{ required "missing elasticsearch-index.cassandra.keyspace!" .Values.cassandra.keyspace }}"

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -3,7 +3,7 @@ elasticsearch:
   #host:  # elasticsearch-client|elasticsearch-ephemeral
   port: 9200
   index: directory
-casandara:
+cassandra:
   # host:
   port: 9042
   keyspace: brig

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -5,8 +5,8 @@ elasticsearch:
   index: directory
 casandara:
   # host:
-  # port: 9042
-  # keyspace: brig
+  port: 9042
+  keyspace: brig
 image:
   repository: quay.io/wire/brig-index
   tag: 2.77.3

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -9,4 +9,4 @@ cassandra:
   keyspace: brig
 image:
   repository: quay.io/wire/brig-index
-  tag: 2.77.3
+  tag: 2.77.11

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -3,11 +3,6 @@ elasticsearch:
   #host:  # elasticsearch-client|elasticsearch-ephemeral
   port: 9200
   index: directory
-hook:
-# when hook.enabled=true (default), this chart does not work standalone, but is intended as
-# either a 'post'-subchart to an elasticsearch chart or a 'pre'-subchart to wire-server
-  enabled: true
-  type: pre # possible values: 'pre' or 'post'
 image:
   repository: quay.io/wire/brig-index
   tag: 2.77.3

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -3,6 +3,10 @@ elasticsearch:
   #host:  # elasticsearch-client|elasticsearch-ephemeral
   port: 9200
   index: directory
+casandara:
+  # host:
+  # port: 9042
+  # keyspace: brig
 image:
   repository: quay.io/wire/brig-index
   tag: 2.77.3


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1142
Depends on https://github.com/wireapp/wire-server/pull/964

Summary of changes:
- The elasticsearch-index chart now mandatorily runs the job to create index pre-uprgade and pre-install
- The create index job also puts mapping
- There is a new post-upgrade and post-install job to run data-migrations on the index.

Deleted values:

- elasticsearch-index.hook.*

New values in the chart:
- elasticsearch-index.cassandra.host
- elasticsearch-index.cassandra.port
- elasticsearch-index.cassandra.keyspace

To do before merge:
- [x] Merge https://github.com/zinfra/cailleach/pull/329