### PR TITLE
Allow network interfaces not being set in inventory for backing services

### DIFF
--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -29,7 +29,7 @@
       bind_host:
         - "_{{ es_network_interface }}_"
         - "_local_"
-    es_masters: '{% for host in groups["elasticsearch_master"] %}{{ hostvars[host]["ansible_" + elasticsearch_network_interface]["ipv4"]["address"] }}:9300{% if not loop.last %},{% endif %}{% endfor %}'
+    es_masters: '{% for host in groups["elasticsearch_master"] %}{{ hostvars[host]["ansible_" + es_network_interface]["ipv4"]["address"] }}:9300{% if not loop.last %},{% endif %}{% endfor %}'
     es_config:
       cluster.name: "elasticsearch-directory"
       http.port: "{{ es_api_port }}" # 9200 by default

--- a/ansible/helm_external.yml
+++ b/ansible/helm_external.yml
@@ -2,8 +2,6 @@
 # that these databases listen on. These files are used as overrides with the
 # <database>-external helm charts (e.g. cassandra-external).
 #
-# Prerequisite: the '<database>_network_interface' must be defined.
-#
 # After any change to IPs/servers:
 # 1. run this playbook:
 #      poetry run ansible-playbook -i hosts.ini helm_external.yml -vv --diff
@@ -24,25 +22,25 @@
       vars:
         external_dir_name: elasticsearch-external
         server_type: elasticsearch
-        network_interface: "{{ elasticsearch_network_interface }}"
+        network_interface: "{{ elasticsearch_network_interface | default('') }}"
 
     - name: Generate minio IPs for helm
       include_tasks: tasks/helm_external.yml
       vars:
         external_dir_name: minio-external
         server_type: minio
-        network_interface: "{{ minio_network_interface }}"
+        network_interface: "{{ minio_network_interface | default('') }}"
 
     - name: Generate cassandra IPs for helm
       include_tasks: tasks/helm_external.yml
       vars:
         external_dir_name: cassandra-external
         server_type: cassandra
-        network_interface: "{{ cassandra_network_interface }}"
+        network_interface: "{{ cassandra_network_interface | default('') }}"
 
     - name: Generate redis IPs for helm
       include_tasks: tasks/helm_external.yml
       vars:
         external_dir_name: redis-external
         server_type: redis
-        network_interface: "{{ redis_network_interface }}"
+        network_interface: "{{ redis_network_interface | default('') }}"

--- a/ansible/templates/helm_external.yaml.j2
+++ b/ansible/templates/helm_external.yaml.j2
@@ -1,4 +1,4 @@
 IPs:
 {% for host in groups[server_type] %}
-  - {{ hostvars[host]["ansible_" + network_interface]["ipv4"]["address"] }}
+  - {{ hostvars[host]["ansible_" + (network_interface | default(hostvars[host].ansible_default_ipv4.interface, true)) ]["ipv4"]["address"] }}
 {% endfor %}


### PR DESCRIPTION
* this change only reflects what is already been claimed in the docs: *Set the network interface name [...] if you have more than one network interface* (docs/how-to/install/ansible-VMs.rst:L123)
* unfortunately, Ansible does not allow reassigning a variable that can be undefined. In that case, Ansible throws and complains about the assigned variable (e.g.`elasticsearch_network_interface`) being undefined. Which makes it necessary do use the `default` filter when including the tasks and handing over variables.
* in the ES playbook `es_network_interface` var is already set at the top and takes proper defaulting into account. It only makes sense to use this value when iterating over master nodes