### PR TITLE
configure maxScimTokens setting

### DIFF
--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -157,6 +157,7 @@ spar:
     ssoUri: https://nginz-https.example.com/sso
     maxttlAuthreq: 28800
     maxttlAuthresp: 28800
+    maxScimTokens: 16
     contacts:
     - type: ContactSupport
       company: YourCompany

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -157,7 +157,7 @@ spar:
     ssoUri: https://nginz-https.example.com/sso
     maxttlAuthreq: 28800
     maxttlAuthresp: 28800
-    maxScimTokens: 16
+    # maxScimTokens: 16 # uncomment this if you want to use SCIM provisioning
     contacts:
     - type: ContactSupport
       company: YourCompany


### PR DESCRIPTION
maxScimTokens value in the chart values file is 0, which prevents the creation of Scim Tokens
I propose to set it to 16 in the values example file.