### PR TITLE
added important envVars to wire-server production values yaml file for Team Settings and Account

### DIFF
--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -214,6 +214,27 @@ team-settings:
       backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
       appHost: webapp.example.com
+  envVars:
+    APP_NAME: "Team Settings"
+    ENFORCE_HTTPS: "false"
+    FEATURE_CHECK_CONSENT: "false"
+    FEATURE_ENABLE_DEBUG: "false"
+    FEATURE_ENABLE_NEW_TEAM: "true"
+    URL_ACCOUNT_BASE: "https://account.example.com"
+    URL_WEBAPP_BASE: "https://webapp.example.com"
+    URL_WEBSITE_BASE: "https://www.example.com"
+    CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
+    CSP_EXTRA_IMG_SRC: "https://*.example.com"
+    CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"
+    CSP_EXTRA_DEFAULT_SRC: "https://*.example.com"
+    CSP_EXTRA_FONT_SRC: "https://*.example.com"
+    CSP_EXTRA_FRAME_SRC: "https://*.example.com"
+    CSP_EXTRA_MANIFEST_SRC: "https://*.example.com"
+    CSP_EXTRA_OBJECT_SRC: "https://*.example.com"
+    CSP_EXTRA_MEDIA_SRC: "https://*.example.com"
+    CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
+    CSP_EXTRA_STYLE_SRC: "https://*.example.com"
+    CSP_EXTRA_WORKER_SRC: "https://*.example.com"
 
 # NOTE: Only relevant if you want account-pages
 account-pages:
@@ -225,3 +246,24 @@ account-pages:
       backendRest: nginz-https.example.com
       backendDomain: example.com
       appHost: webapp.example.com
+  envVars:
+    APP_NAME: "Wire Account Management"
+    COMPANY_NAME: "YourCompany"
+    FEATURE_ENFORCE_HTTPS: "false"
+    FEATURE_ENABLE_DEBUG: "false"
+    URL_SUPPORT_BASE: "https://www.example.com/support"
+    URL_TEAMS_BASE: "https://teams.example.com"
+    URL_WEBAPP_BASE: "https://webapp.example.com"
+    URL_WEBSITE_BASE: "https://www.example.com"
+    CSP_EXTRA_CONNECT_SRC: "https://*.example.com, wss://*.example.com"
+    CSP_EXTRA_IMG_SRC: "https://*.example.com"
+    CSP_EXTRA_SCRIPT_SRC: "https://*.example.com"
+    CSP_EXTRA_DEFAULT_SRC: "https://*.example.com"
+    CSP_EXTRA_FONT_SRC: "https://*.example.com"
+    CSP_EXTRA_FRAME_SRC: "https://*.example.com"
+    CSP_EXTRA_MANIFEST_SRC: "https://*.example.com"
+    CSP_EXTRA_OBJECT_SRC: "https://*.example.com"
+    CSP_EXTRA_MEDIA_SRC: "https://*.example.com"
+    CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
+    CSP_EXTRA_STYLE_SRC: "https://*.example.com"
+    CSP_EXTRA_WORKER_SRC: "https://*.example.com"


### PR DESCRIPTION
CSP vars are needed otherwise team settings and account pages do not work correctly.
URL_ACCOUNT_BASE in Team Settings is needed otherwise the URL displayed in the "SSO login URL" field is "https://account.wire.com/start-sso/wire-xxxx" instead of the account URL of our own platform.
Added other useful vars that were hidden in .env.defaults files.