### PR TITLE
added settings to Terraform inventory file

### DIFF
--- a/terraform/examples/inventory.tpl
+++ b/terraform/examples/inventory.tpl
@@ -42,6 +42,10 @@ ${list_elasticsearch}
 [elasticsearch_master:children]
 elasticsearch
 
+[elasticsearch:vars]
+# Put a hold on the ES package. Updating ES to a different version that 6.6 currently breaks its integration with Wire.
+es_version_lock = True
+
 [cassandra:vars]
 is_aws_environment = False
 # cassandra_clustername = default
@@ -74,6 +78,11 @@ ansible_python_interpreter = /usr/bin/python3
 # cassandra_network_interface = vpn0
 # redis_network_interface = vpn0
 # registry_network_interface = vpn0
+# restund_network_interface = vpn0
+
+## configure a proxy if one is needed to access the Internet
+# http_proxy = ""
+# https_proxy = ""
 
 ### KUBERNETES (see kubespray documentation for details) ###
 


### PR DESCRIPTION
- proxy configuration for enterprise environments that have to use a proxy to access the Internet
- restund network interface specification, otherwise it was not working correctly on my platform
- version lock on ES package because apt-upgrading by mistake from version 6.6.0 to 6.8.8 breaks ES service: Exception in thread "main" java.nio.file.NoSuchFileException: /etc/elasticsearch/jvm.options