### PR TITLE
configure proxy env vars in some charts

### DIFF
--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -66,24 +66,26 @@ spec:
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
-          {{- end }}      
+            value: {{ join "," .noProxyList | quote }}
+          {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -66,10 +66,18 @@ spec:
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}            
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -66,18 +66,24 @@ spec:
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+          {{- if .Values.config.proxy.httpProxy }}
           - name: http_proxy
             value: {{ .Values.config.proxy.httpProxy | quote }}
-          - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
-          - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: HTTP_PROXY
             value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
           - name: HTTPS_PROXY
             value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}            
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}      
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -74,9 +74,9 @@ config:
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
   proxy:
-    http_proxy: ""
-    https_proxy: ""
-    no_proxy: ""
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""
 turnStatic:
   v1:
   - turn:localhost:3478

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -79,3 +79,6 @@ turnStatic:
   v2:
   - turn:localhost:3478
   - turn:localhost:3478?transport=tcp
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -73,12 +73,13 @@ config:
     # setUserMaxPermClients: <int>
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
+  proxy:
+    http_proxy: ""
+    https_proxy: ""
+    no_proxy: ""
 turnStatic:
   v1:
   - turn:localhost:3478
   v2:
   - turn:localhost:3478
   - turn:localhost:3478?transport=tcp
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -73,10 +73,7 @@ config:
     # setUserMaxPermClients: <int>
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}
 turnStatic:
   v1:
   - turn:localhost:3478

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -54,18 +54,24 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
+          {{- if .Values.config.proxy.httpProxy }}
           - name: http_proxy
             value: {{ .Values.config.proxy.httpProxy | quote }}
-          - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
-          - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: HTTP_PROXY
             value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
           - name: HTTPS_PROXY
             value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: NO_PROXY
             value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -54,10 +54,18 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -54,24 +54,26 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -16,7 +16,4 @@ config:
   logLevel: Info
   aws:
     s3Bucket: assets
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -16,6 +16,7 @@ config:
   logLevel: Info
   aws:
     s3Bucket: assets
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -16,3 +16,6 @@ config:
   logLevel: Info
   aws:
     s3Bucket: assets
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -56,18 +56,24 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+          {{- if .Values.config.proxy.httpProxy }}
           - name: http_proxy
             value: {{ .Values.config.proxy.httpProxy | quote }}
-          - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
-          - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: HTTP_PROXY
             value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
           - name: HTTPS_PROXY
             value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: NO_PROXY
             value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -56,10 +56,18 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -56,24 +56,26 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -27,6 +27,7 @@ config:
       legalhold: disabled-by-default
   aws:
     region: "eu-west-1"
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -27,3 +27,6 @@ config:
       legalhold: disabled-by-default
   aws:
     region: "eu-west-1"
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -27,7 +27,4 @@ config:
       legalhold: disabled-by-default
   aws:
     region: "eu-west-1"
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -56,18 +56,24 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+          {{- if .Values.config.proxy.httpProxy }}
           - name: http_proxy
             value: {{ .Values.config.proxy.httpProxy | quote }}
-          - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
-          - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: HTTP_PROXY
             value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
           - name: HTTPS_PROXY
             value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
           - name: NO_PROXY
             value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -56,10 +56,18 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -56,24 +56,26 @@ spec:
                 key: awsSecretKey
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -22,6 +22,7 @@ config:
   bulkPush: false
   aws:
     region: "eu-west-1"
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -22,3 +22,6 @@ config:
   bulkPush: false
   aws:
     region: "eu-west-1"
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -22,7 +22,4 @@ config:
   bulkPush: false
   aws:
     region: "eu-west-1"
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -44,10 +44,24 @@ spec:
           - name: "proxy-config"
             mountPath: "/etc/wire/proxy/conf"
           env:
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          {{- if .Values.config.proxy.httpProxy }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -44,24 +44,26 @@ spec:
           - name: "proxy-config"
             mountPath: "/etc/wire/proxy/conf"
           env:
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -43,6 +43,11 @@ spec:
             mountPath: "/etc/wire/proxy/secrets"
           - name: "proxy-config"
             mountPath: "/etc/wire/proxy/conf"
+          env:
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -14,6 +14,7 @@ resources:
     cpu: "500m"
 config:
   logLevel: Debug
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -14,7 +14,4 @@ resources:
     cpu: "500m"
 config:
   logLevel: Debug
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -14,3 +14,6 @@ resources:
     cpu: "500m"
 config:
   logLevel: Debug
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
           volumeMounts:
           - name: "spar-config"
             mountPath: "/etc/wire/spar/conf"
+          env:
+      {{- range $key, $val := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+      {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -38,24 +38,26 @@ spec:
           - name: "spar-config"
             mountPath: "/etc/wire/spar/conf"
           env:
-          {{- if .Values.config.proxy.httpProxy }}
+          {{- with .Values.config.proxy }}
+          {{- if .httpProxy }}
           - name: http_proxy
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           - name: HTTP_PROXY
-            value: {{ .Values.config.proxy.httpProxy | quote }}
+            value: {{ .httpProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.httpsProxy }}
+          {{- if .httpsProxy }}
           - name: https_proxy
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           - name: HTTPS_PROXY
-            value: {{ .Values.config.proxy.httpsProxy | quote }}
+            value: {{ .httpsProxy | quote }}
           {{- end }}
-          {{- if .Values.config.proxy.noProxy }}
+          {{- if .noProxyList }}
           - name: no_proxy
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           - name: NO_PROXY
-            value: {{ .Values.config.proxy.noProxy | quote }}
+            value: {{ join "," .noProxyList | quote }}
           {{- end }}
+          {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -38,10 +38,24 @@ spec:
           - name: "spar-config"
             mountPath: "/etc/wire/spar/conf"
           env:
-      {{- range $key, $val := .Values.envVars }}
-          - name: {{ $key }}
-            value: {{ $val | quote }}
-      {{- end }}
+          {{- if .Values.config.proxy.httpProxy }}
+          - name: http_proxy
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          - name: HTTP_PROXY
+            value: {{ .Values.config.proxy.httpProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.httpsProxy }}
+          - name: https_proxy
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.config.proxy.httpsProxy | quote }}
+          {{- end }}
+          {{- if .Values.config.proxy.noProxy }}
+          - name: no_proxy
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.config.proxy.noProxy | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -20,6 +20,7 @@ config:
   logLevel: Info
   maxttlAuthreq: 7200
   maxttlAuthresp: 7200
-# NOTE: Without an empty dictionary, you will see warnings
-#       when overriding envVars
-envVars: {}
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -20,7 +20,4 @@ config:
   logLevel: Info
   maxttlAuthreq: 7200
   maxttlAuthresp: 7200
-  proxy:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
+  proxy: {}

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -20,3 +20,6 @@ config:
   logLevel: Info
   maxttlAuthreq: 7200
   maxttlAuthresp: 7200
+# NOTE: Without an empty dictionary, you will see warnings
+#       when overriding envVars
+envVars: {}

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -3,8 +3,8 @@ tags:
   spar: false # enable if you want/need Single-Sign-On (SSO)
 
 cassandra-migrations:
-  # images:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  images:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   cassandra:
     host: cassandra-ephemeral
     replicaCount: 1
@@ -15,8 +15,8 @@ elasticsearch-index:
 
 brig:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-ephemeral
@@ -47,34 +47,53 @@ brig:
       host: demo-smtp # change this if you want to use your own SMTP server
       port: 25        # change this
       connType: plain # change this. Possible values: plain|ssl|tls
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 proxy:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  config:
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 cannon:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   # For demo mode only, we don't need to keep websocket connections open on chart upgrades
   drainTimeout: 10
 
 cargohold:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     aws:
       # change if using real AWS
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
       s3DownloadEndpoint: https://assets.example.com
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 galley:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-ephemeral
@@ -82,11 +101,17 @@ galley:
     settings:
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://example.com/join/ # change this
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 gundeck:
   replicaCount: 1
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-ephemeral
@@ -99,15 +124,21 @@ gundeck:
       queueName: integration-gundeck-events
       sqsEndpoint: http://fake-aws-sqs:4568
       snsEndpoint: http://fake-aws-sns:4575
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 nginz:
   replicaCount: 1
   config:
     ws:
       useProxyProtocol: false
-  # images:
-  #   nginz:
-  #     tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  images:
+#    nginz:
+#      tag: some-tag (only override if you want a newer/different version than what is in the chart)
   nginx_conf:
     # using prod means mostly that some internal endpoints are not exposed
     env: prod
@@ -118,8 +149,8 @@ nginz:
 
 webapp:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com
@@ -129,8 +160,8 @@ webapp:
 
 team-settings:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com
@@ -140,8 +171,8 @@ team-settings:
 
 account-pages:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -3,8 +3,8 @@ tags:
   proxy: false # enable if you want/need giphy/youtube/etc proxying
 
 cassandra-migrations:
-  # images:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  images:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   cassandra:
     host: cassandra-external
     replicaCount: 3
@@ -15,8 +15,8 @@ elasticsearch-index:
 
 brig:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-external
@@ -65,6 +65,12 @@ brig:
       host: demo-smtp # change this if you want to use your own SMTP server
       port: 25        # change this
       connType: plain # change this. Possible values: plain|ssl|tls
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
   turnStatic:
     v1:
       - "turn:turn01.example.com:80"
@@ -77,31 +83,44 @@ brig:
 
 proxy:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  config:
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 cannon:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   # For demo mode only, we don't need to keep websocket connections open on chart upgrades
   drainTimeout: 10
 
 cargohold:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     aws:
       # change if using real AWS
       s3Bucket: assets
       s3Endpoint: http://minio-external:9000
       s3DownloadEndpoint: https://assets.example.com
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 galley:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-external
@@ -109,11 +128,17 @@ galley:
     settings:
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://webapp.example.com/join/ # change this
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 gundeck:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-external
@@ -126,15 +151,21 @@ gundeck:
       queueName: integration-gundeck-events
       sqsEndpoint: http://fake-aws-sqs:4568
       snsEndpoint: http://fake-aws-sns:4575
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 nginz:
   replicaCount: 3
   config:
     ws:
       useProxyProtocol: false
-  # images:
-  #   nginz:
-  #     tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  images:
+#    nginz:
+#      tag: some-tag (only override if you want a newer/different version than what is in the chart)
   nginx_conf:
     # using prod means mostly that some internal endpoints are not exposed
     env: prod
@@ -145,8 +176,8 @@ nginz:
 
 spar:
   replicaCount: 3
-  # image:
-  #   tag: some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     cassandra:
       host: cassandra-external
@@ -161,11 +192,17 @@ spar:
     - type: ContactSupport
       company: YourCompany
       email: email:support@example.com
+#    proxy: 
+#      httpProxy: "http://proxy.example.com"
+#      httpsProxy: "bar"
+#      noProxyList: 
+#        - "local.example.com"
+#        - "10.23.0.0/16"
 
 webapp:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com
@@ -206,8 +243,8 @@ webapp:
 # NOTE: Only relevant if you want team-settings
 team-settings:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com
@@ -218,8 +255,8 @@ team-settings:
 # NOTE: Only relevant if you want account-pages
 account-pages:
   replicaCount: 1
-  # image:
-  #   tag: # some-tag (only override if you want a newer/different version than what is in the chart)
+#  image:
+#    tag: some-tag (only override if you want a newer/different version than what is in the chart)
   config:
     externalUrls:
       backendRest: nginz-https.example.com


### PR DESCRIPTION
In some enterprise environments, a proxy is needed to access the Internet.
Some pods need to access the Internet to access AWS, a cloud Object Storage provider if not using local Minio instance, Giphy, etc...
This change permits admins to configure http_proxy, https_proxy and no_proxy env vars inside these pods, from the wire-server values yaml file.