### PR TITLE
Add missing cassandra host value for elasticsearch-index chart

### DIFF
--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -12,6 +12,8 @@ cassandra-migrations:
 elasticsearch-index:
   elasticsearch:
     host: elasticsearch-ephemeral
+  cassandra:
+    host: cassandra-ephemeral
 
 brig:
   replicaCount: 1

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -12,6 +12,8 @@ cassandra-migrations:
 elasticsearch-index:
   elasticsearch:
     host: elasticsearch-external
+  cassandra:
+    host: cassandra-external
 
 brig:
   replicaCount: 3


### PR DESCRIPTION
This missing value currently breaks rendering wire-server helm chart when using those examples values files.