### PR TITLE
[terraform] add module to initialize state sharing on AWS

### DIFF
--- a/terraform/modules/aws_terraform-state-share/README.md
+++ b/terraform/modules/aws_terraform-state-share/README.md
@@ -1,0 +1,29 @@
+Terraform module: Terraform state facility
+==========================================
+
+Ensures the existence of locations in which a Terraform state is stored and locked. It allows working in a collaborative
+and distributed fashion on any kind of Terraform code.
+
+It should be a one-time setup that doesn't need to be touched. Though, the module allows to be destroyed.
+
+It makes use of the following AWS services:
+
+* S3 bucket (Object Storage)
+* DynamoDB (document-based Database)
+
+In order to destroy the previously created instance, one can
+
+* use the AWS web console
+* needs to import the existing state before, like
+```
+terraform import \
+    -var 'bucket_name=${myStateBucketName}' \
+    -var 'table_name=${myStateLockTableName}' \
+    module.${myModuleInstanceName}.aws_s3_bucket.terraform-state-storage \
+    ${myStateBucketName}
+```
+
+More documentation here:
+
+* https://medium.com/@jessgreb01/how-to-terraform-locking-state-in-s3-2dc9a5665cb6
+* https://www.terraform.io/docs/backends/types/s3.html

--- a/terraform/modules/aws_terraform-state-share/main.tf
+++ b/terraform/modules/aws_terraform-state-share/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12"
+}

--- a/terraform/modules/aws_terraform-state-share/providers.tf
+++ b/terraform/modules/aws_terraform-state-share/providers.tf
@@ -1,0 +1,8 @@
+# NOTE: the provider assums that the respective environemnt variables,
+# reuqired for authentication, already being set
+#
+provider "aws" {
+  version = "~> 2.58"
+
+  region = var.region
+}

--- a/terraform/modules/aws_terraform-state-share/resources.tf
+++ b/terraform/modules/aws_terraform-state-share/resources.tf
@@ -1,0 +1,33 @@
+# create an S3 bucket to store the state file in
+resource "aws_s3_bucket" "terraform-state-storage" {
+  bucket = var.bucket_name
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Name = "S3 Remote Terraform State Store"
+  }
+}
+
+# create a dynamodb table for locking the state file
+resource "aws_dynamodb_table" "terraform-state-lock" {
+  name           = var.table_name
+  hash_key       = "LockID"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name = "DynamoDB Terraform State Lock Table"
+  }
+}

--- a/terraform/modules/aws_terraform-state-share/variables.tf
+++ b/terraform/modules/aws_terraform-state-share/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  type        = string
+  default     = "eu-central-1"
+  description = "defines in which region state and lock are being stored"
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "the name of the bucket, which needs to be globally unique"
+}
+
+variable "table_name" {
+  type        = string
+  description = "name of the DynamoDB table which holds the lock to accessing the terraform state"
+}


### PR DESCRIPTION
Since it is reused in various places, it might be worth having a module for this. Here is how it can be used:

```terraform
terraform {
  required_version = "~> 0.12"
}

variable "stateBucket" {
  type = string
}

variable "stateLockTable" {
  type = string
}

module "initiate-tf-state-sharing" {
  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws_terraform-state-share?ref=tf-module_init-state-share"
  bucket_name = var.stateBucket
  table_name = var.stateLockTable
}
```