### PR TITLE
Leave domain empty in cookies, making UAs default to server host.

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -154,7 +154,6 @@ data:
       setTwilio: /etc/wire/brig/secrets/twilio-credentials.yaml
       setNexmo: /etc/wire/brig/secrets/nexmo-credentials.yaml
       setUserMaxConnections: {{ .setUserMaxConnections }}
-      setCookieDomain: {{ .setCookieDomain }}
       setCookieInsecure: {{ .setCookieInsecure }}
       setUserCookieRenewAge: {{ .setUserCookieRenewAge }}
       setUserCookieLimit: {{ .setUserCookieLimit }}

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -39,7 +39,6 @@ brig:
       teamCreatorWelcome: https://teams.example.com/login # change this
       teamMemberWelcome: https://wire.example.com/download # change this
     optSettings:
-      setCookieDomain: example.com # change this
     emailSMS:
       general:
         emailSender: email@example.com # change this

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -39,8 +39,6 @@ brig:
       teamSettings: https://teams.example.com # change this (or unset if team settings are not used)
       teamCreatorWelcome: https://teams.example.com/login # change this
       teamMemberWelcome: https://wire.example.com/download # change this
-    optSettings:
-      setCookieDomain: example.com # change this
     emailSMS:
       general:
         emailSender: email@example.com # change this


### PR DESCRIPTION
Depends on https://github.com/wireapp/wire-server/pull/1076

Fixes https://github.com/zinfra/backend-issues/issues/953