### PR TITLE
Fix helm --wait for cassandra

### DIFF
--- a/charts/cassandra-ephemeral/values.yaml
+++ b/charts/cassandra-ephemeral/values.yaml
@@ -2,6 +2,9 @@
 cassandra-ephemeral:
   persistence:
     enabled: false
+  # Needed for https://github.com/helm/helm/issues/7424
+  updateStrategy:
+    type: RollingUpdate
   resources:
     requests:
       memory: "2.0Gi"


### PR DESCRIPTION
Helm 3 doesn't `--wait` for  StatefulSets that are not of type RollingUpdate