### PR TITLE
[WIP] Add module to instantiate groups of EC2 instances that share a majority of configuration

### DIFF
--- a/terraform/modules/aws-machines/README.md
+++ b/terraform/modules/aws-machines/README.md
@@ -39,7 +39,7 @@ module "machines" {
   role = "mytestrole"
 
   image = {
-    filter = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-"
+    filter = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
     owner = "099720109477"  # Canonical
     hypervisor = "hvm"
   }

--- a/terraform/modules/aws-machines/README.md
+++ b/terraform/modules/aws-machines/README.md
@@ -1,0 +1,71 @@
+Terraform module: instantiate and manage a group of AWS EC2 instances 
+=====================================================================
+
+State: __experimental__
+
+
+#### How to use the module
+
+##### Module instances required to exist 
+
+```hcl
+variable "environment" {
+  type        = string
+  description = "name of the environemnt of this state"
+}
+
+module "vpc" {
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-vpc?ref=tf-module_aws-machines"
+  name        = var.environment
+  environment = var.environment
+}
+
+module "security_groups" {
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-vpc-security-groups?ref=tf-module_aws-machines"
+  vpc_id = module.vpc.vpc_id
+}
+```
+
+##### Instantiate machines
+
+```hcl
+module "machines" {
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-machines?ref=tf-module_aws-machines"
+
+  region = "eu-central-1"
+
+  environment = var.environment
+  type = "m5.large"
+  role = "mytestrole"
+
+  image = {
+    filter = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-"
+    owner = "099720109477"  # Canonical
+    hypervisor = "hvm"
+  }
+  volume_size = 20
+
+  security_groups = [
+    module.security_groups.talk_to_assets,
+    module.security_groups.has_ssh,
+    module.security_groups.k8s_private,
+    module.security_groups.talk_to_stateful,
+    module.security_groups.k8s_node
+  ]
+
+  instances = [
+    {
+      name = "mymachine1",
+      subnet = module.vpc.private_subnets[1]
+    },
+    {
+      name = "mymachine3",
+      subnet = module.vpc.private_subnets[1]
+    },
+    {
+      name = "mymachine2",
+      subnet = module.vpc.private_subnets[0]
+    }
+  ]
+}
+```

--- a/terraform/modules/aws-machines/data.ami.tf
+++ b/terraform/modules/aws-machines/data.ami.tf
@@ -1,0 +1,15 @@
+data "aws_ami" "instance_image" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.image.filter]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = [var.image.hypervisor]
+  }
+
+  owners = [var.image.owner]
+}

--- a/terraform/modules/aws-machines/data.ami.tf
+++ b/terraform/modules/aws-machines/data.ami.tf
@@ -1,4 +1,6 @@
 data "aws_ami" "instance_image" {
+  count = length(var.instances) > 0 ? 1 : 0
+
   most_recent = true
 
   filter {

--- a/terraform/modules/aws-machines/main.tf
+++ b/terraform/modules/aws-machines/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12"
+}

--- a/terraform/modules/aws-machines/providers.tf
+++ b/terraform/modules/aws-machines/providers.tf
@@ -1,8 +1,0 @@
-# NOTE: the provider assums that the respective environemnt variables,
-# reuqired for authentication, are being set in parent module
-#
-provider "aws" {
-  version = "~> 2.58"
-
-  region = var.region
-}

--- a/terraform/modules/aws-machines/providers.tf
+++ b/terraform/modules/aws-machines/providers.tf
@@ -1,0 +1,8 @@
+# NOTE: the provider assums that the respective environemnt variables,
+# reuqired for authentication, are being set in parent module
+#
+provider "aws" {
+  version = "~> 2.58"
+
+  region = var.region
+}

--- a/terraform/modules/aws-machines/resources.ec2.tf
+++ b/terraform/modules/aws-machines/resources.ec2.tf
@@ -1,0 +1,28 @@
+resource "aws_instance" "machine" {
+  ami           = data.aws_ami.instance_image.id
+
+  // NOTE: the trick is to use a self-provided uID as identifier not an index of a list, otherwise
+  // TF reshuffles things removes the wrong instance
+  // see https://medium.com/@yashvanzara/terraform-deleting-an-element-from-a-list-cb5bdadc8bbd
+  for_each = { for i,v in var.instances : lookup(v, "name") => v }
+
+  instance_type = lookup(each.value, "type", null) != null ? lookup(each.value, "type") : var.type
+
+  subnet_id = lookup(each.value, "subnet", null) != null ? lookup(each.value, "subnet") : var.subnet
+  key_name = var.sshkey
+
+  root_block_device {
+    volume_size = lookup(each.value, "volume_size", null) != null ? tonumber(lookup(each.value, "volume_size")) : var.volume_size
+  }
+
+  vpc_security_group_ids = var.security_groups
+
+  tags = merge(
+    {
+      Name        = "${var.environment}-${lookup(each.value, "name")}",
+      Environment = var.environment,
+      Role        = var.role
+    },
+    var.tags
+  )
+}

--- a/terraform/modules/aws-machines/resources.ec2.tf
+++ b/terraform/modules/aws-machines/resources.ec2.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "machine" {
-  ami           = data.aws_ami.instance_image.id
+  ami           = data.aws_ami.instance_image[0].id
 
   // NOTE: the trick is to use a self-provided uID as identifier not an index of a list, otherwise
   // TF reshuffles things removes the wrong instance

--- a/terraform/modules/aws-machines/variables.ami.tf
+++ b/terraform/modules/aws-machines/variables.ami.tf
@@ -1,0 +1,8 @@
+variable "image" {
+  type = object({
+    filter = string
+    owner = string
+    hypervisor = string
+  })
+  description = "AMI information"
+}

--- a/terraform/modules/aws-machines/variables.ec2.tf
+++ b/terraform/modules/aws-machines/variables.ec2.tf
@@ -1,0 +1,54 @@
+variable "instances" {
+  type = list(
+    // NOTE: due to adequard sysntax implementation, we hav e to allow any structure and
+    //       and do the defaulting where values are being used
+    // see: https://github.com/hashicorp/terraform/issues/19898
+    //
+    map(any)
+//  object({
+//    name = string,     # NOTE: required; must be unique
+//    type = string,
+//    volume_size = string,
+//    subnet = string
+//  })
+  )
+  default = [ ]
+}
+
+
+variable "type" {
+  type = string
+  default = null
+}
+
+variable "subnet" {
+  type = string
+  default = null
+}
+
+variable "sshkey" {
+  type = string
+  default = null
+}
+
+variable "volume_size" {
+  type = string
+  default = null
+}
+
+variable "role" {
+  type = string
+  description = "sets the roles of the instances being created"
+}
+
+variable "security_groups" {
+  type = list(string)
+  description = "list of VPC security group references"
+  default = []
+}
+
+variable "tags" {
+  type = map(string)
+  description = "map of AWS instance tags"
+  default = {}
+}

--- a/terraform/modules/aws-machines/variables.tf
+++ b/terraform/modules/aws-machines/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  type        = string
+  description = "defines in which region state and lock are being stored (default: 'eu-central-1')"
+  default     = "eu-central-1"
+}
+
+variable "environment" {
+  type        = string
+  description = "name of the environment as a scope for the created resources (default: 'dev'; example: 'prod', 'staging')"
+  default     = "dev"
+}


### PR DESCRIPTION
This is an initial attempt to abstract the life cycle of a group of similar machines (EC2 instances). It was briefly discussed and the following aspects were pointed out

* any automatically defined mapping mechanism that requires a particular order would break when a machines is being removed
* favouring naming conventions over explicit module inputs (e.g. `security_groups`) by using *data* resources to obtain these kind of references
* only 5 security groups at a time can be assigned to an instance, therefore we would need to group them and utilize naming conventions 

For now, this effort is put on hold and postponed to a later point in time, where aspects mentioned above have to be revisited again.