### PR TITLE
[TF modules] Ensure that no provider is defined in any of the modules

### DIFF
--- a/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/providers.tf
+++ b/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/providers.tf
@@ -1,8 +1,0 @@
-# NOTE: the provider assums that the respective environemnt variables,
-# reuqired for authentication, are being set in parent module
-#
-provider "aws" {
-  version = "~> 2.58"
-
-  region = var.region
-}

--- a/terraform/modules/aws-cargohold-asset-storage/providers.tf
+++ b/terraform/modules/aws-cargohold-asset-storage/providers.tf
@@ -1,8 +1,0 @@
-# NOTE: the provider assums that the respective environemnt variables,
-# reuqired for authentication, are being set in parent module
-#
-provider "aws" {
-  version = "~> 2.58"
-
-  region = var.region
-}

--- a/terraform/modules/aws-gundeck-push-notifications/providers.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/providers.tf
@@ -1,8 +1,0 @@
-# NOTE: the provider assums that the respective environemnt variables,
-# reuqired for authentication, are being set in parent module
-#
-provider "aws" {
-  version = "~> 2.58"
-
-  region = var.region
-}


### PR DESCRIPTION
* remove provider in cargohold, gundeck, brig modules
* it's recommended to only configure provider in the root module [1]
  either implicit (provider directive) or explicit within module instantiation
  (e.g. `module.myModule.providers`)

[1] https://www.terraform.io/docs/configuration/modules.html#providers-within-modules