### PR TITLE
fix smtpCredentials to match EmailSMTPCredentials in brig Options.hs

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -64,8 +64,8 @@ data:
         smtpConnType: {{ .smtp.connType }}
         {{- if .smtp.username }}
         smtpCredentials:
-          username: {{ .smtp.username }}
-          password: {{ .smtp.passwordFile }}
+          smtpUsername: {{ .smtp.username }}
+          smtpPassword: {{ .smtp.passwordFile }}
         {{- end }}
       {{- end }}
       general:


### PR DESCRIPTION
to fix issue #264 - though I think it would be prettier to change Option.hs instead so that you have 
```
data EmailSMTPCredentials = EmailSMTPCredentials
  { -- | Username to authenticate
    --   against the SMTP server
    username :: !Text,
    -- | File containing password to
    --   authenticate against the SMTP server
    password :: !FilePathSecrets
  }
  deriving (Show, Generic)
```
but this will get things working without having to monkey around with wire-server