### PR TITLE
Make field sesQueue to be required in case AWS SES is being configured

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
     emailSMS:
       email:
       {{- if .useSES }}
-        sesQueue: {{ .aws.sesQueue }}
+        sesQueue: {{ required "Missing value: brig.aws.sesQueue" .aws.sesQueue }}
         sesEndpoint: {{ .aws.sesEndpoint | quote }}
       {{- else }}
         smtpEndpoint:


### PR DESCRIPTION
* helm doesn't seem to fail if a sub-field is not set, not even if it's not
  defined as default in $chartName/values.yaml
* case: `aws.useSES: true` and `./values` example files don't list it as
* ths commit introduced the expected behaviour: throw if required while not
  mentioned in any of the example values files

Fixes https://github.com/wireapp/wire-server-deploy/issues/266