### PR TITLE
[TF modules] Ensure uniqueness of cargohold bucket name

### DIFF
--- a/terraform/modules/aws-cargohold-asset-storage/resources.s3.tf
+++ b/terraform/modules/aws-cargohold-asset-storage/resources.s3.tf
@@ -11,7 +11,7 @@ resource "random_string" "bucket" {
   number = true
   special = false
 
-  keepers {
+  keepers = {
     env = var.environment
     name = var.bucket_name
   }

--- a/terraform/modules/aws-cargohold-asset-storage/resources.s3.tf
+++ b/terraform/modules/aws-cargohold-asset-storage/resources.s3.tf
@@ -1,5 +1,18 @@
 resource "aws_s3_bucket" "asset_storage" {
-  bucket = "${var.environment}-${var.bucket_name}"
+  bucket = "${random_string.bucket.keepers.env}-${random_string.bucket.keepers.name}-cargohold-${random_string.bucket.result}"
   acl    = "private"
   region = var.region
+}
+
+resource "random_string" "bucket" {
+  length = 8
+  lower = true
+  upper = false
+  number = true
+  special = false
+
+  keepers {
+    env = var.environment
+    name = var.bucket_name
+  }
 }


### PR DESCRIPTION
since buckets are AWS-global (or at least region-global) the
naming so far was not unique enough, so we use a random suffix,
which will change every time env or name changes (see, `keepers`)