### PR TITLE
Release 2020-05-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2020-05-25
+
+- Fix typo in default galley helm values: teamSearchVisibility (#271)
+- Make field brig.config.aws.sesQueue to be required if being used (#268)
+
 # 2020-05-15
 
 ## Upgrade Notes

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
     emailSMS:
       email:
       {{- if .useSES }}
-        sesQueue: {{ .aws.sesQueue }}
+        sesQueue: {{ required "Missing value: brig.aws.sesQueue" .aws.sesQueue }}
         sesEndpoint: {{ .aws.sesEndpoint | quote }}
       {{- else }}
         smtpEndpoint:

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -28,7 +28,7 @@ config:
     featureFlags:  # see #RefConfigOptions in `/docs/reference` (https://github.com/wireapp/wire-server/)
       sso: disabled-by-default
       legalhold: disabled-by-default
-      teamSearchVisibiliy: disabled-by-default
+      teamSearchVisibility: disabled-by-default
   aws:
     region: "eu-west-1"
   proxy: {}


### PR DESCRIPTION
# Changes

- Fix typo in default galley helm values: teamSearchVisibility (#271)
- Make field brig.config.aws.sesQueue to be required if being used (#268)