### PR TITLE
Quote smsSender

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -74,7 +74,7 @@ data:
       general:
         templateDir: /usr/share/wire/templates
         emailSender: {{ .emailSMS.general.emailSender }}
-        smsSender: {{ .emailSMS.general.smsSender }}
+        smsSender: {{ .emailSMS.general.smsSender | quote }}
         templateBranding:
           {{- with .emailSMS.general.templateBranding }}
           brand: {{ .brand }}


### PR DESCRIPTION
A mobile number will be parsed into an integer, which is not compatible with the type definition is Brig's Haskell code

Fixes https://github.com/wireapp/wire-server-deploy/issues/285