### PR TITLE
Add ingress rule to allow NLB to talk to k8s

### DIFF
--- a/terraform/modules/aws-vpc-security-groups/main.tf
+++ b/terraform/modules/aws-vpc-security-groups/main.tf
@@ -210,6 +210,17 @@ resource "aws_security_group" "k8s_node" {
     security_groups = ["${aws_security_group.talk_to_k8s.id}"]
   }
 
+  # incoming from NLB
+  ingress {
+    from_port       = 31772
+    to_port         = 31773
+    protocol        = "tcp"
+    security_groups = [
+      # NOTE: NLBs dont allow security groups to be be set on them, which is why
+      # there is none for egress and also not referred in here
+    ]
+  }
+
   # FIXME: tighten this up.
   ingress {
     from_port       = 0

--- a/terraform/modules/aws-vpc-security-groups/main.tf
+++ b/terraform/modules/aws-vpc-security-groups/main.tf
@@ -216,7 +216,7 @@ resource "aws_security_group" "k8s_node" {
     to_port         = 31773
     protocol        = "tcp"
     # NOTE: NLBs dont allow security groups to be be set on them, which is why
-    # we go with the CIDR for now, which is hard-coded adn evil and needs fixing
+    # we go with the CIDR for now, which is hard-coded and evil and needs fixing
     cidr_blocks = ["172.17.0.0/20"]
   }
 
@@ -445,4 +445,3 @@ resource "aws_security_group" "stateful_node" {
     Name = "stateful_node"
   }
 }
-

--- a/terraform/modules/aws-vpc-security-groups/main.tf
+++ b/terraform/modules/aws-vpc-security-groups/main.tf
@@ -215,10 +215,9 @@ resource "aws_security_group" "k8s_node" {
     from_port       = 31772
     to_port         = 31773
     protocol        = "tcp"
-    security_groups = [
-      # NOTE: NLBs dont allow security groups to be be set on them, which is why
-      # there is none for egress and also not referred in here
-    ]
+    # NOTE: NLBs dont allow security groups to be be set on them, which is why
+    # we go with the CIDR for now, which is hard-coded adn evil and needs fixing
+    cidr_blocks = ["172.17.0.0/20"]
   }
 
   # FIXME: tighten this up.


### PR DESCRIPTION
The origin of the ports can be found [here](https://github.com/wireapp/wire-server-deploy/blob/develop/charts/nginx-ingress-controller/values.yaml#L88-L89).