### PR TITLE
[chart:team-settings] Rollback to v2.10

### DIFF
--- a/charts/team-settings/templates/deployment.yaml
+++ b/charts/team-settings/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             value: https://{{ .Values.config.externalUrls.backendRest }}
           - name: BACKEND_WS
             value: wss://{{ .Values.config.externalUrls.backendWebsocket }}
+            # NOTE defaults to 'true', but since we assume on-prem here, we default to 'false'
+            # SRC https://github.com/wireapp/wire-web-config-default/blob/master/wire-team-settings/.env.defaults#L48
+          - name: FEATURE_ENABLE_PAYMENT
+            value: {{ .Values.config.enablePayment | default false | quote }}
       {{- range $key, $val := .Values.envVars }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -168,7 +168,7 @@ team-settings:
       backendRest: nginz-https.example.com
       backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
-      appHost: webapp.example.com
+      appHost: teams.example.com
 
 account-pages:
   replicaCount: 1
@@ -178,4 +178,4 @@ account-pages:
     externalUrls:
       backendRest: nginz-https.example.com
       backendDomain: example.com
-      appHost: webapp.example.com
+      appHost: account.example.com

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -257,7 +257,7 @@ team-settings:
       backendRest: nginz-https.example.com
       backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
-      appHost: webapp.example.com
+      appHost: teams.example.com
   envVars:
     APP_NAME: "Team Settings"
     ENFORCE_HTTPS: "false"
@@ -289,7 +289,7 @@ account-pages:
     externalUrls:
       backendRest: nginz-https.example.com
       backendDomain: example.com
-      appHost: webapp.example.com
+      appHost: account.example.com
   envVars:
     APP_NAME: "Wire Account Management"
     COMPANY_NAME: "YourCompany"


### PR DESCRIPTION
Version 2.11-2.12 are broken, because stripe broke in a minor version release.
According to web-team, setting `FEATURE_ENABLE_PAYMENT="false"` should have done
the trick, but it didnt. So we fall back to v2.10.
Furthermore, this makes `FEATURE_ENABLE_PAYMENT` defaulting to `false`. Since we
consider Helm deployments to be on-prem where billing for teams is not a thing.

This also fixes our example files. Each frontend app has to refer to its own FQDN.