### PR TITLE
[charts] Update frontend apps version: webapp, team-settings

### DIFF
--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: 14965-2.12.0-9c23a0-v0.24.68-production
+  tag: 15522-2.13.0-45540f-v0.24.79-production
 service:
   https:
     externalPort: 443

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 52663-0.1.0-b524bd-v0.24.72-production
+  tag: 53287-0.1.0-a268bc-v0.24.78-production
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
This change mainly aims to fix a broken account-settings version.

* webapp: https://github.com/wireapp/wire-webapp/releases/tag/2020-06-24-production.0 ([diff](https://github.com/wireapp/wire-webapp/compare/2020-01-06-production.0...2020-06-24-production.0))
* team-settings: https://github.com/wireapp/wire-team-settings/releases/tag/v2.13.0 ([diff](https://github.com/wireapp/wire-team-settings/compare/v2.10.0...v2.13.0))
* account-pages: https://github.com/wireapp/wire-account/releases/tag/v2.1.0 [diff](https://github.com/wireapp/wire-account/compare/v2.0.2...v2.1.0))

NOTE: added version & diff info for all frontend apps, since they were missing from the recent version bump