### PR TITLE
removed unused replicaCount settings

### DIFF
--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -22,7 +22,6 @@ brig:
   config:
     cassandra:
       host: cassandra-external
-      replicaCount: 3
     elasticsearch:
       host: elasticsearch-external
     useSES: false
@@ -128,7 +127,6 @@ galley:
   config:
     cassandra:
       host: cassandra-external
-      replicaCount: 3
     settings:
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://webapp.example.com/join/ # change this
@@ -148,7 +146,6 @@ gundeck:
   config:
     cassandra:
       host: cassandra-external
-      replicaCount: 3
     aws:
       # change if using real AWS
       account: "123456789012"
@@ -187,7 +184,6 @@ spar:
   config:
     cassandra:
       host: cassandra-external
-      replicaCount: 3
     logLevel: Debug
     domain: example.com
     appUri: https://nginz-https.example.com


### PR DESCRIPTION
These replicaCount settings (at the level they are in the values yaml file) are not used anywhere in the charts.