### PR TITLE
Provide AWS_REGION variable to cargohold

### DIFF
--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
+          - name: AWS_REGION
+            value: "{{ .Values.config.aws.region }}"
           {{- with .Values.config.proxy }}
           {{- if .httpProxy }}
           - name: http_proxy

--- a/charts/cargohold/templates/tests/cargohold-integration.yaml
+++ b/charts/cargohold/templates/tests/cargohold-integration.yaml
@@ -17,4 +17,12 @@ spec:
     volumeMounts:
     - name: "cargohold-integration"
       mountPath: "/etc/wire/integration"
+    env:
+    # these dummy values are necessary for Amazonka's "Discover"
+    - name: AWS_ACCESS_KEY_ID
+      value: "dummy"
+    - name: AWS_SECRET_ACCESS_KEY
+      value: "dummy"
+    - name: AWS_REGION
+      value: "eu-west-1"
   restartPolicy: Never

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -15,5 +15,6 @@ resources:
 config:
   logLevel: Info
   aws:
+    region: "eu-west-1"
     s3Bucket: assets
   proxy: {}


### PR DESCRIPTION
See https://github.com/zinfra/backend-issues/issues/488

Now with [cargohold using V4 signatures](https://github.com/wireapp/wire-server/pull/1157), the region is part of the Authorization header and needs to configured correctly. We already do that for the other services, so I just copied the code from there.