### PR TITLE
[tf-module:dns-records] Add output for FQDNs

### DIFF
--- a/terraform/modules/aws-dns-records/outputs.tf
+++ b/terraform/modules/aws-dns-records/outputs.tf
@@ -1,0 +1,6 @@
+output "fqdns" {
+  value = concat(
+    [for record in aws_route53_record.a : record.fqdn],
+    [for record in aws_route53_record.cname : record.fqdn]
+  )
+}


### PR DESCRIPTION
Since the FQDNs are assembled within the module, it make sense to expose those, so that the same logic is not getting re-implemented.