### PR TITLE
nginz redirect /teams/invitations/by-email to brig

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -225,6 +225,10 @@ nginx_conf:
       envs:
       - all
       disable_zauth: true
+    - path: ~* ^/teams/invitations/by-email$
+      envs:
+      - all
+      disable_zauth: true
     - path: /i/teams/invitation-code
       envs:
       - staging


### PR DESCRIPTION
add nginz unauthenticated endpoint for pending invitation request
See also https://github.com/zinfra/backend-issues/issues/1489
and related PR https://github.com/wireapp/wire-server/pull/1168