### PR TITLE
README.md: stop explicitly referring to the "develop" branch

### DIFF
--- a/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/README.md
+++ b/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/README.md
@@ -29,8 +29,8 @@ mandatory.
 
 ```hcl
 module "brig_prekey_lock_and_event_queue_emailing" {
-  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-brig-prekey-lock-event-queue-email-sending?ref=develop"
-  
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-brig-prekey-lock-event-queue-email-sending?ref=CHANGE-ME"
+
   environment = "staging"
 
   zone_id = "Z12345678SQWERTYU"
@@ -42,8 +42,8 @@ module "brig_prekey_lock_and_event_queue_emailing" {
 
 ```hcl
 module "brig_prekey_lock_and_event_queue" {
-  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-brig-prekey-lock-event-queue-email-sending?ref=develop"
-  
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-brig-prekey-lock-event-queue-email-sending?ref=CHANGE-ME"
+
   environment = "staging"
   enable_email_sending = false    # default: true
 }

--- a/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/README.md
+++ b/terraform/modules/aws-brig-prekey-lock-event-queue-email-sending/README.md
@@ -1,4 +1,4 @@
-Terraform module: Brig pre-key locking, event queue (optional: email sending) 
+Terraform module: Brig pre-key locking, event queue (optional: email sending)
 =============================================================================
 
 State: __experimental__
@@ -9,7 +9,7 @@ in cassandra to avoid race conditions), and (B) to establish a message queue
 for internal events (used e.g. during user deletions).
 
 [Optional] Wire-server's "brig" components needs to send emails. This can either
-be done by configuring an SMTP server (Option 1), or by using AWS resources (Option 2).           
+be done by configuring an SMTP server (Option 1), or by using AWS resources (Option 2).
 This terraform module can enable brig to send emails using option 2. In addition, it
 configures *MAIL FROM* for outgoing emails, but does not enable incoming emails
 (possible solution: `aws_ses_receipt_rule`).

--- a/terraform/modules/aws-cargohold-asset-storage/README.md
+++ b/terraform/modules/aws-cargohold-asset-storage/README.md
@@ -23,8 +23,8 @@ mandatory.
 
 ```hcl
 module "cargohold_asset_storage" {
-  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-cargohold-asset-storage?ref=develop"
-  
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-cargohold-asset-storage?ref=CHANGE-ME"
+
   environment = "staging"
 }
 ```

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -15,8 +15,8 @@ AWS resources: route53
 
 ```hcl
 module "dns_records" {
-  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-dns-records?ref=develop"
-  
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-dns-records?ref=CHANGE-ME"
+
   environment = "staging"
 
   zone_fqdn = "example.com"

--- a/terraform/modules/aws-gundeck-push-notifications/README.md
+++ b/terraform/modules/aws-gundeck-push-notifications/README.md
@@ -18,8 +18,8 @@ mandatory.
 
 ```hcl
 module "gundeck-push-notification" {
-  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-gundeck-push-notifications?ref=develop"
-  
+  source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-gundeck-push-notifications?ref=CHANGE-ME"
+
   environment = "dev"
   apns_application_id = "myapp.tld"
   apns_voip_key = file("path/to/app-credentials/key.pem")


### PR DESCRIPTION
When instantiating a terraform module, versioning matters.

By just encouraging users to have this loosely track the mutable
"develop" branch, breakages can suddenly occur. Instead, push
versioning, and version bumps to the ones initializing the terraform
modules.


Context: Cleanup in preparation for https://github.com/wireapp/wire-server-deploy/pull/299#discussion_r459350847.