### PR TITLE
Update TLS config

### DIFF
--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -126,8 +126,8 @@ data:
         ssl_session_cache builtin:1000 shared:SSL:10m;
         ssl_session_timeout 5m;
         ssl_prefer_server_ciphers on;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers 'EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS';
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
 
         server {
           listen {{ .Values.service.internalPort }};


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1628

Note that this also disables TLS versions we don't want and enables TLS 1.3. Le me know when there's a reason why that doesn't work.