### PR TITLE
Add default AWS region to example values files

### DIFF
--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -28,6 +28,7 @@ brig:
     useSES: false
     aws:
       # change if using real AWS
+      region: "eu-west-1"
       sqsEndpoint: http://fake-aws-sqs:4568
       dynamoDBEndpoint: http://fake-aws-dynamodb:4567
       # these must match the table names created on fake or real AWS services
@@ -81,6 +82,7 @@ cargohold:
   config:
     aws:
       # change if using real AWS
+      region: "eu-west-1"
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
       s3DownloadEndpoint: https://assets.example.com
@@ -102,6 +104,8 @@ galley:
     settings:
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://example.com/join/ # change this
+    aws:
+      region: "eu-west-1"
 #    proxy: 
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
@@ -120,7 +124,7 @@ gundeck:
     aws:
       # change if using real AWS
       account: "123456789012"
-      region: eu-west-1
+      region: "eu-west-1"
       arnEnv: integration
       queueName: integration-gundeck-events
       sqsEndpoint: http://fake-aws-sqs:4568

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -110,6 +110,7 @@ cargohold:
   config:
     aws:
       # change if using real AWS
+      region: "eu-west-1"
       s3Bucket: assets
       s3Endpoint: http://minio-external:9000
       s3DownloadEndpoint: https://assets.example.com


### PR DESCRIPTION
For consistency between different services as well as `demo-values` and `prod-values`
This makes it more obvious that this value might need to be modified if the default is not desired.

The default for cargohold was introduced in https://github.com/wireapp/wire-server-deploy/commit/cc2d5c3f102ad30b3b208a8a3ee95354ec356894.

@lucendio Thanks for making me aware!