### PR TITLE
[sft] Add srv-announcer role to the SFT deployment automation

### DIFF
--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -9,3 +9,4 @@
 - hosts: sft_servers
   roles:
     - role: sft-server
+    - role: srv-announcer

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -66,4 +66,4 @@
 
 - src: git+https://github.com/wireapp/ansible-sft.git
   name: sft
-  version: "20d4f19685777ed3f4d11fa100bdbdd4a7e2ce1f" # master (2020-09-16)
+  version: "369db98e2e1ddf156ea0c9dbd2801c9d83e10a5a" # master (2020-09-25)

--- a/terraform/environment/inventory.tf
+++ b/terraform/environment/inventory.tf
@@ -12,16 +12,12 @@ resource "local_file" "inventory" {
         "ansible_python_interpreter" = "/usr/bin/python3"
         "sft_fqdn" = instance.fqdn
 
-        "announcer_zone_domain" = var.root_domain
-        "announcer_aws_key_id" = module.sft[0].sft.aws_key_id
-        "announcer_aws_access_key" = module.sft[0].sft.aws_access_key
-        "announcer_aws_region" = module.sft[0].sft.aws_region
-        "announcer_srv_records" = {
-          "sft" = {
-            "name" = "_sft._tcp.${var.environment}"
-            "target" = instance.fqdn
-          }
-        }
+        "srv_announcer_zone_domain" = var.root_domain
+        "srv_announcer_aws_key_id" = module.sft[0].sft.aws_key_id
+        "srv_announcer_aws_access_key" = module.sft[0].sft.aws_access_key
+        "srv_announcer_aws_region" = module.sft[0].sft.aws_region
+        "srv_announcer_record_name": "_sft._tcp.${var.environment}"
+        "srv_announcer_record_target": instance.fqdn
       }}
     }
   })


### PR DESCRIPTION
Update variables in the inventory template to match the latest version of
the role and pin to the corresponding commit.
Moved from 'roles' directive in the playbook to 'import_role' in order to
import roles instead of including them.