### PR TITLE
[tf-module:push-notifications] Allow to define multiple apps per client platform

### DIFF
--- a/terraform/modules/aws-gundeck-push-notifications/resources.iam.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.iam.tf
@@ -39,10 +39,10 @@ resource "aws_iam_user_policy" "gundeck" {
                   "sns:SetEndpointAttributes",
                   "sns:Publish"
               ],
-              "Resource": [
-                  "${aws_sns_platform_application.gcm.arn}",
-                  "${aws_sns_platform_application.apns_voip.arn}"
-              ]
+              "Resource": ${jsonencode(concat(
+                [for _, v in aws_sns_platform_application.android : v.arn],
+                [for _, v in aws_sns_platform_application.ios : v.arn]
+              ))}
           }
       ]
   }

--- a/terraform/modules/aws-gundeck-push-notifications/resources.iam.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.iam.tf
@@ -11,6 +11,8 @@ resource "aws_iam_access_key" "gundeck" {
 # and to consume messages from the SQS queues
 #
 resource "aws_iam_user_policy" "gundeck" {
+  count = length(aws_sns_platform_application.apps) > 0 ? 1 : 0
+
   name = "${var.environment}-gundeck-full-access-policy"
   user = aws_iam_user.gundeck.name
 
@@ -39,10 +41,9 @@ resource "aws_iam_user_policy" "gundeck" {
                   "sns:SetEndpointAttributes",
                   "sns:Publish"
               ],
-              "Resource": ${jsonencode(concat(
-                [for _, v in aws_sns_platform_application.android : v.arn],
-                [for _, v in aws_sns_platform_application.ios : v.arn]
-              ))}
+              "Resource": ${jsonencode(
+                [for _, v in aws_sns_platform_application.apps : v.arn]
+              )}
           }
       ]
   }

--- a/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
@@ -1,8 +1,15 @@
 # Create platform applications for iOS and Android. At the moment, only VoIP is being used for iOS
 
 resource "aws_sns_platform_application" "ios" {
-  for_each = { for _, app in var.ios_applications : app.id => app }
-  name     = "${var.environment}-${each.value.id}"
+  for_each = {
+    for _, app_platform in flatten([
+      for _, app in var.ios_applications : [
+        for _, platform in app.platforms : merge({ platform = platform }, app)
+      ]
+    ]) : "${app_platform.id}-${app_platform.platform}" => app_platform
+  }
+
+  name = "${var.environment}-${each.value.id}"
   # ^-- <env>-<bundleID>
   #  <env> should match the env on gundeck's config
   #  <bundleID> name of the application, which is bundled/hardcoded when the app is built
@@ -24,8 +31,15 @@ resource "aws_sns_platform_application" "ios" {
 }
 
 resource "aws_sns_platform_application" "android" {
-  for_each = { for _, app in var.android_applications : app.id => app }
-  name     = "${var.environment}-${each.value.id}"
+  for_each = {
+    for _, app_platform in flatten([
+      for _, app in var.android_applications : [
+        for _, platform in app.platforms : merge({ platform = platform }, app)
+      ]
+    ]) : "${app_platform.id}-${app_platform.platform}" => app_platform
+  }
+
+  name = "${var.environment}-${each.value.id}"
   # ^-- <env>-<projectID>
   #
   # <env> should match the env on gundeck's config

--- a/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
@@ -1,55 +1,105 @@
-# Create platform applications for iOS and Android. At the moment, only VoIP is being used for iOS
+# Create platform applications for iOS and Android.
 
-resource "aws_sns_platform_application" "ios" {
-  for_each = {
-    for _, app_platform in flatten([
-      for _, app in var.ios_applications : [
-        for _, platform in app.platforms : merge({ platform = platform }, app)
-      ]
-    ]) : "${app_platform.id}-${app_platform.platform}" => app_platform
+locals {
+
+  # NOTE: Well, well, well, we got ourselves yet another 'bug' - or more precisely - an unexpected
+  #       behaviour. One would think, that
+  #
+  #           concat(var.ios_applications, var.android_applications)
+  #
+  #       would be the plausible choice for this task, but no, here comes Terraform.
+  #       'Hold my beer', it says: https://github.com/hashicorp/terraform/issues/26090
+  #       tl;dr It eats all the fields that are NOT part of the items's intersection
+  #       because different types. Admittedly, a reasonable explanation, but unexpected
+  #       nonetheless. In order to work around it, we are pulling out the iron.
+  applications = flatten([var.ios_applications, var.android_applications])
+
+  # NOTE: What is a platform? AWS lingua for all the different push notification services (see comment in the resource)
+  #       This nested iteration replaces each entry of 'applications' with a list of application <-> platform
+  #       combinations and adds the 'platform' field to each of them
+  # EXAMPLE:
+  #  [
+  #    [
+  #      {
+  #        id = "com.myapp"
+  #        platform = "APNS"
+  #        platforms = ["APNS","APNS_VOIP"]
+  #        key = "REDACTED"
+  #        cert = "REDACTED"
+  #      },
+  #      {
+  #        id = "com.myapp"
+  #        platform = "APNS_VOIP"
+  #        platforms = ["APNS","APNS_VOIP"]
+  #        key = "REDACTED"
+  #        cert = "REDACTED"
+  #      }
+  #    ],
+  #    [
+  #      {
+  #        id = "123456789"
+  #        platform = "GCM"
+  #        platforms = ["GCM"]
+  #        key = "REDACTED"
+  #        cert = "REDACTED"
+  #      }
+  #    ]
+  #  ]
+  #
+  app_platforms_lists = [
+    for _, app in local.applications : [
+      for _, platform in app.platforms : merge(app, { platform = platform })
+    ]
+  ]
+
+  # NOTE: get rid of the nested lists being generated
+  flattened_app_platforms_list = flatten(local.app_platforms_lists)
+
+  # NOTE: converts in to a map with the following identifier syntax: '${id}-${platform}'
+  #       for each application <-> platform combination
+  # EXAMPLE:
+  #  {
+  #    "com.myapp-APNS" = {
+  #      id = "com.myapp"
+  #      platform = "APNS"
+  #      platforms = ["APNS","APNS_VOIP"]
+  #      key = "REDACTED"
+  #      cert = "REDACTED"
+  #    },
+  #    ...
+  #  }
+  #
+  app_platforms_map = {
+    for _, app_platform in local.flattened_app_platforms_list
+      : "${app_platform.id}-${app_platform.platform}" => app_platform
   }
 
-  name = "${var.environment}-${each.value.id}"
-  # ^-- <env>-<bundleID>
-  #  <env> should match the env on gundeck's config
-  #  <bundleID> name of the application, which is bundled/hardcoded when the app is built
-  #
-  # The name of the app is IMPORTANT! If it does not follow the pattern, then apps will not be able
-  # to register for push notifications
-  # More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
-  #
-  platform = each.value.platform
-  # ^-- We only use VoIP at the moment
-  platform_principal = each.value.cert
-  # ^-- Path to the public certificate
-  platform_credential = each.value.key
-  # ^-- Path to the private key
-  event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
-  # ^-- Topic to subscribe to
-  event_endpoint_updated_topic_arn = aws_sns_topic.device_state_changed.arn
-  # ^-- Topic to subscribe to
 }
 
-resource "aws_sns_platform_application" "android" {
-  for_each = {
-    for _, app_platform in flatten([
-      for _, app in var.android_applications : [
-        for _, platform in app.platforms : merge({ platform = platform }, app)
-      ]
-    ]) : "${app_platform.id}-${app_platform.platform}" => app_platform
-  }
+resource "aws_sns_platform_application" "apps" {
+  for_each = local.app_platforms_map
 
+  # The name of the app is IMPORTANT! If it does not follow the pattern, then apps will not be able
+  # to register for push notifications
+  # [iOS] More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
+  # [Android] More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
+  #
   name = "${var.environment}-${each.value.id}"
-  # ^-- <env>-<projectID>
-  #
-  # <env> should match the env on gundeck's config
-  # <projectID> name of the firebase project (this is unique across all firebase projects)
-  #
-  # More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
-  #
-  platform            = each.value.platform
+  # ^-- [iOS] <env>-<bundleID>
+  # ^-- [Android] <env>-<projectID>
+  #  <env> should match the env on gundeck's config
+  #  <bundleID> name of the application, which is bundled/hardcoded when the app is built
+  #  <projectID> name of the firebase project (this is unique across all firebase projects)
+
+  # NOTE: possible values https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html#sns-attrib-mobile-reserved
+  platform = each.value.platform
+
   platform_credential = each.value.key
-  # ^-- Path to the secret token
+  # ^-- [iOS] Content of to the private key
+  # ^-- [Android] Content of the secret token
+  platform_principal = lookup(each.value, "cert", null)
+  # ^-- [iOS] Content of the public certificate
+
   event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
   # ^-- Topic to subscribe to
   event_endpoint_updated_topic_arn = aws_sns_topic.device_state_changed.arn

--- a/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
@@ -1,7 +1,8 @@
 # Create platform applications for iOS and Android. At the moment, only VoIP is being used for iOS
 
-resource "aws_sns_platform_application" "apns_voip" {
-  name = "${var.environment}-${var.apns_application_id}"
+resource "aws_sns_platform_application" "ios" {
+  for_each = { for _, app in var.ios_applications : app.id => app }
+  name     = "${var.environment}-${each.value.id}"
   # ^-- <env>-<bundleID>
   #  <env> should match the env on gundeck's config
   #  <bundleID> name of the application, which is bundled/hardcoded when the app is built
@@ -10,11 +11,11 @@ resource "aws_sns_platform_application" "apns_voip" {
   # to register for push notifications
   # More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
   #
-  platform = "APNS_VOIP"
+  platform = each.value.platform
   # ^-- We only use VoIP at the moment
-  platform_principal = var.apns_voip_cert
+  platform_principal = each.value.cert
   # ^-- Path to the public certificate
-  platform_credential = var.apns_voip_key
+  platform_credential = each.value.key
   # ^-- Path to the private key
   event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
   # ^-- Topic to subscribe to
@@ -22,8 +23,9 @@ resource "aws_sns_platform_application" "apns_voip" {
   # ^-- Topic to subscribe to
 }
 
-resource "aws_sns_platform_application" "gcm" {
-  name = "${var.environment}-${var.gcm_application_id}"
+resource "aws_sns_platform_application" "android" {
+  for_each = { for _, app in var.android_applications : app.id => app }
+  name     = "${var.environment}-${each.value.id}"
   # ^-- <env>-<projectID>
   #
   # <env> should match the env on gundeck's config
@@ -31,8 +33,8 @@ resource "aws_sns_platform_application" "gcm" {
   #
   # More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
   #
-  platform            = "GCM"
-  platform_credential = var.gcm_key
+  platform            = each.value.platform
+  platform_credential = each.value.key
   # ^-- Path to the secret token
   event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
   # ^-- Topic to subscribe to

--- a/terraform/modules/aws-gundeck-push-notifications/variables.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/variables.tf
@@ -12,34 +12,25 @@ variable "environment" {
 
 
 # Check https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
-variable "apns_application_id" {
-  type        = string
-  description = "iOS application name (aka app ID), e.g. 'wire.com'"
-}
-
-# docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
-variable "apns_voip_key" {
-  type        = string
-  description = "content of the key file"
-}
-
-# docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
-variable "apns_voip_cert" {
-  type        = string
-  description = "content of the cert file"
+variable "ios_applications" {
+  type = list(object({
+    id       = string # iOS application name (aka app ID), e.g. 'wire.com'
+    platform = string
+    key      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
+    cert     = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
+  }))
+  description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
 }
 
 
 # Check https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
-variable "gcm_application_id" {
-  type        = string
-  description = "Android application name (aka sender ID), e.g. '482078210000'"
-}
-
-# docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
-variable "gcm_key" {
-  type        = string
-  description = "content of the key file"
+variable "android_applications" {
+  type = list(object({
+    id       = string # Android application name (aka sender ID), e.g. '482078210000'
+    platform = string
+    key      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
+  }))
+  description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
 }
 
 

--- a/terraform/modules/aws-gundeck-push-notifications/variables.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/variables.tf
@@ -20,6 +20,7 @@ variable "ios_applications" {
     cert      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
+  default = []
 }
 
 
@@ -31,6 +32,7 @@ variable "android_applications" {
     key       = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
+  default = []
 }
 
 

--- a/terraform/modules/aws-gundeck-push-notifications/variables.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/variables.tf
@@ -14,10 +14,10 @@ variable "environment" {
 # Check https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
 variable "ios_applications" {
   type = list(object({
-    id       = string # iOS application name (aka app ID), e.g. 'wire.com'
-    platform = string
-    key      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
-    cert     = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
+    id        = string # iOS application name (aka app ID), e.g. 'wire.com'
+    platforms = list(string)
+    key       = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
+    cert      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
 }
@@ -26,9 +26,9 @@ variable "ios_applications" {
 # Check https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
 variable "android_applications" {
   type = list(object({
-    id       = string # Android application name (aka sender ID), e.g. '482078210000'
-    platform = string
-    key      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
+    id        = string # Android application name (aka sender ID), e.g. '482078210000'
+    platforms = list(string)
+    key       = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
 }


### PR DESCRIPTION
__NOTE:__ This is a breaking change and requires Terraform state migration ('terraform state mv')

Due to the fact that multiple different clients (app/build ID) can be connected to
the same backend and at the same time desire to receive push notifications, it should
be possible to register those apps to the same events/notifications queue.

*preliminary work for: https://github.com/zinfra/backend-issues/issues/1794*