### PR TITLE
Support keeping old SFT servers while creating new ones with differen…

### DIFF
--- a/terraform/environment/sft.tf
+++ b/terraform/environment/sft.tf
@@ -3,6 +3,11 @@ variable "sft_server_names" {
   type = list(string)
 }
 
+variable "sft_server_names_stale" {
+  default = []
+  type = list(string)
+}
+
 variable "sft_a_record_ttl" {
   default = 60
 }
@@ -11,8 +16,12 @@ variable "sft_server_type" {
   default = "cx11"
 }
 
+variable "sft_server_type_stale" {
+  default = "cx11"
+}
+
 module "sft" {
-  count = min(1, length(var.sft_server_names))
+  count = min(1, length(concat(var.sft_server_names_stale, var.sft_server_names)))
 
   source = "../modules/sft"
   root_domain = var.root_domain
@@ -23,4 +32,6 @@ module "sft" {
   image = var.hcloud_image
   location = var.hcloud_location
   ssh_keys = local.hcloud_ssh_keys
+  server_names_stale = var.sft_server_names_stale
+  server_type_stale = var.sft_server_type_stale
 }

--- a/terraform/modules/sft/dns.tf
+++ b/terraform/modules/sft/dns.tf
@@ -3,7 +3,7 @@ data "aws_route53_zone" "sft_zone" {
 }
 
 resource "aws_route53_record" "sft_a" {
-  for_each = var.server_names
+  for_each = setunion(var.server_names, var.server_names_stale)
 
   zone_id = data.aws_route53_zone.sft_zone.zone_id
   name    = "sft${each.value}.sft.${var.environment}"

--- a/terraform/modules/sft/outputs.tf
+++ b/terraform/modules/sft/outputs.tf
@@ -8,7 +8,7 @@ output "sft" {
     aws_key_id = aws_iam_access_key.srv-announcer.id
     aws_access_key = aws_iam_access_key.srv-announcer.secret
     aws_region = data.aws_region.current.name
-    instances = [ for server_name in var.server_names :
+    instances = [ for server_name, _ in local.map_server_name_to_type :
       {
         hostname = hcloud_server.sft[server_name].name
         ipaddress = hcloud_server.sft[server_name].ipv4_address

--- a/terraform/modules/sft/server.tf
+++ b/terraform/modules/sft/server.tf
@@ -1,8 +1,15 @@
-resource "hcloud_server" "sft" {
-  for_each = var.server_names
+locals {
+  map_server_name_to_type_stale = {for _, server_name in  var.server_names_stale: server_name => var.server_type_stale}
+  map_server_name_to_type_fresh = {for _, server_name in var.server_names : server_name => var.server_type}
+  map_server_name_to_type = merge(local.map_server_name_to_type_stale, local.map_server_name_to_type_fresh)
+}
 
-  name = "${var.environment}-sft-${each.value}"
-  server_type = var.server_type
+
+resource "hcloud_server" "sft" {
+  for_each = local.map_server_name_to_type
+
+  name = "${var.environment}-sft-${each.key}"
+  server_type = each.value
   image = var.image
   location = var.location
   ssh_keys = var.ssh_keys

--- a/terraform/modules/sft/variables.tf
+++ b/terraform/modules/sft/variables.tf
@@ -11,6 +11,12 @@ variable "server_names" {
   type = set(string)
 }
 
+variable "server_names_stale" {
+  #TODO: Make this better
+  description = "List of names of stale sft servers. The server will be availables at sft<name>.<environment>.<root_domain>, ideally these shouldn't be touched by terraform"
+  type = set(string)
+}
+
 variable "a_record_ttl" {
   type = number
 }
@@ -20,6 +26,10 @@ variable "metrics_srv_record_ttl" {
 }
 
 variable "server_type" {
+  default = "cx11"
+}
+
+variable "server_type_stale" {
   default = "cx11"
 }
 


### PR DESCRIPTION
…t server_type

This change allows making changes to the sft_server type to have a transition with servers of different types (e.g. moving from cx.11 to cx.31 without destroying or stopping exisiting servers)