### PR TITLE
Skip creating SFT monitoring certs if there are not SFT servers

### DIFF
--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -5,6 +5,7 @@
   become: no
   roles:
     - role: sft-monitoring-certs
+      when: "{{ (groups['sft_servers'] | length) > 0 }}"
 
 - hosts: sft_servers
   roles:


### PR DESCRIPTION
This isn't required for environments which don't have any SFT servers.