### PR TITLE
add support for cargohold s3Compatibility option

### DIFF
--- a/charts/cargohold/templates/configmap.yaml
+++ b/charts/cargohold/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
       {{- if .s3DownloadEndpoint }}
       s3DownloadEndpoint: {{ .s3DownloadEndpoint }}
       {{- end }}
+      {{- if .s3Compatibility }}
+      s3Compatibility: {{ .s3Compatibility }}
+      {{- end }}
       {{ if .cloudFront }}
       cloudFront:
         domain: {{ .cloudFront.domain }}


### PR DESCRIPTION
See https://github.com/zinfra/backend-issues/issues/1659 and https://github.com/wireapp/wire-server/pull/1234.