### PR TITLE
Delete the SFT SRV record after provsioning

### DIFF
--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -42,5 +42,5 @@
         type: "SRV"
         record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
         state: "delete"
-        value: '{{ srv_records.set.value }}'
-        ttl: '{{ srv_records.set.ttl }}'
+        value: "{{ srv_records.set.value }}"
+        ttl: "{{ srv_records.set.ttl }}"

--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -25,3 +25,22 @@
         owner: root
         group: root
         state: link
+
+- hosts: localhost
+  become: no
+  tasks:
+    - name: Get all SRV recoreds
+      route53:
+        zone: "{{ root_domain }}"
+        type: "SRV"
+        record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
+        state: get
+      register: srv_records
+    - name: Delete all SRV records
+      route53:
+        zone: "{{ root_domain }}"
+        type: "SRV"
+        record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
+        state: "delete"
+        value: '{{ srv_records.set.value }}'
+        ttl: '{{ srv_records.set.ttl }}'


### PR DESCRIPTION
This will ensure that any deactivated SFT servers don't linger around due to
race between different SRV announcers.