### PR TITLE
[ansible] Allow custom log dir when pulling logs from an instance

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -71,7 +71,8 @@ endif
 		--extra-vars "log_host=${LOG_HOST}" \
 		--extra-vars "log_service=${LOG_SERVICE}" \
 		--extra-vars "log_since=${LOG_SINCE}" \
-		--extra-vars "log_until=${LOG_UNTIL}"
+		--extra-vars "log_until=${LOG_UNTIL}" \
+		--extra-vars "log_dir=${LOG_DIR}"
 
 .PHONY: ensure-env-dir
 ensure-env-dir:

--- a/ansible/get-logs.yml
+++ b/ansible/get-logs.yml
@@ -3,9 +3,15 @@
     - name: get logs
       shell: journalctl -u {{ log_service }} --since {{ log_since }} --until {{ log_until }}
       register: the_logs
+    - name: create logs directory
+      delegate_to: localhost
+      become: no
+      file:
+        state: directory
+        path: "{{ log_dir | default('/tmp', true) }}"
     - name: save logs
       delegate_to: localhost
       become: no
       copy:
-        dest: /tmp/{{log_host}}-{{ log_service }}-{{ log_since }}-{{ log_until }}
+        dest: "{{ log_dir | default('/tmp', true) }}/{{log_host}}-{{ log_service }}-{{ log_since }}-{{ log_until }}.log"
         content: "{{ the_logs.stdout }}"


### PR DESCRIPTION
Falls back to `/tmp`