### PR TITLE
Use less latest tags

### DIFF
--- a/charts/cassandra-migrations/templates/migrate-schema.yaml
+++ b/charts/cassandra-migrations/templates/migrate-schema.yaml
@@ -76,5 +76,5 @@ spec:
             - "{{ .Values.cassandra.replicaCount }}"
       containers:
         - name: job-done
-          image: busybox
+          image: busybox:1.32.0
           command: ['sh', '-c', 'echo "gundeck, brig, galley, spar schema cassandra-migrations completed. See initContainers for details with e.g. kubectl logs ... -c gundeck-schema"']

--- a/charts/demo-smtp/templates/deployment.yaml
+++ b/charts/demo-smtp/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image }}"
           env:
         {{- range $key, $val := .Values.envVars }}
             - name: {{ $key }}

--- a/charts/demo-smtp/values.yaml
+++ b/charts/demo-smtp/values.yaml
@@ -1,8 +1,6 @@
 fullnameOverride: demo-smtp
 replicaCount: 1
-image:
-  repository: namshi/smtp
-  tag: latest
+image: "namshi/smtp@sha256:aa63b8de68ce63dfcf848c56f3c1a16d81354f4accd4242a0086c57dd5a91d77"
 
 service:
   port: 25


### PR DESCRIPTION
Having a `latest` tag in a image in k8s causes it to have a
imagePullPolicy: always, which fails in offline setups.

Cherry picked from nix-ansible branch