### PR TITLE
[charts] Bump versions for webapp, account-pages, team-settings

### DIFF
--- a/charts/account-pages/values.yaml
+++ b/charts/account-pages/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/account
-  tag: 4543-2.1.0-e0f7f1-v0.24.72-production
+  tag: 2.1.4-5f9c54-v0.26.5-production
 service:
   https:
     externalPort: 443

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: 15522-2.13.0-45540f-v0.24.79-production
+  tag: 3.1.0-131bc5-v0.26.5-production
 service:
   https:
     externalPort: 443

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "53834-0.1.0-4dbb18-v0.24.86-staging"
+  tag: "2020-11-09-production.0-dd6d2e-v0.27.5-production"
 service:
   https:
     externalPort: 443

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -217,6 +217,7 @@ webapp:
       backendDomain: example.com
       backendTeamSettings: teams.example.com
       appHost: webapp.example.com
+  # See full list of available environment variables: https://github.com/wireapp/wire-webapp/blob/dev/server/config.ts
   envVars:
     APP_NAME: "Webapp"
     ENFORCE_HTTPS: "false"
@@ -231,6 +232,7 @@ webapp:
     URL_PRIVACY_POLICY: "https://www.example.com/terms-conditions"
     URL_SUPPORT_BASE: "https://www.example.com/support"
     URL_TEAMS_BASE: "https://teams.example.com"
+    URL_TEAMS_CREATE: "https://teams.example.com"
     URL_TERMS_OF_USE_PERSONAL: "https://www.example.com/terms-conditions"
     URL_TERMS_OF_USE_TEAMS: "https://www.example.com/terms-conditions"
     URL_WEBSITE_BASE: "https://www.example.com"
@@ -258,6 +260,7 @@ team-settings:
       backendWebsocket: nginz-ssl.example.com
       backendDomain: example.com
       appHost: teams.example.com
+  # See full list of available environment variables: https://github.com/wireapp/wire-team-settings/blob/dev/server/config.ts
   envVars:
     APP_NAME: "Team Settings"
     ENFORCE_HTTPS: "false"
@@ -290,6 +293,7 @@ account-pages:
       backendRest: nginz-https.example.com
       backendDomain: example.com
       appHost: account.example.com
+  # See full list of available environment variables: https://github.com/wireapp/wire-account/blob/dev/server/config.ts
   envVars:
     APP_NAME: "Wire Account Management"
     COMPANY_NAME: "YourCompany"


### PR DESCRIPTION
Went through the diff for each frontends w/o discovering any breaking changes
(even though team-settings e.g. suggested it - apparently it was a mistake).

The tag was done by hand, since the automation over there is 'not able' to
incorporate the release version yet.

Added links in values examples for easier discovery.