### PR TITLE
charts/cannon:  Use hostname -f to discover cannon's own FQDN

### DIFF
--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - -c
         # e.g. cannon-0.cannon.production
-        - echo "${HOSTNAME}.{{ .Values.service.name }}.{{ .Release.Namespace }}" > /etc/wire/cannon/externalHost/host.txt
+        - hostname -f > /etc/wire/cannon/externalHost/host.txt
         volumeMounts:
         - name: empty
           mountPath: /etc/wire/cannon/externalHost


### PR DESCRIPTION
Requires less templating and still is correct.

> For example, given a Pod with the hostname set to "busybox-1" and the subdomain set to "default-subdomain", and a headless Service named "default-subdomain" in the same namespace, the pod will see its own FQDN as "busybox-1.default-subdomain.my-namespace.svc.cluster-domain.example".

https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields