### PR TITLE
charts/legalhold: introduce

### DIFF
--- a/charts/legalhold/Chart.yaml
+++ b/charts/legalhold/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for legalhold
+name: legalhold
+version: 0.124.0

--- a/charts/legalhold/requirements.yaml
+++ b/charts/legalhold/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: postgresql
+    version: 9.8.12
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/legalhold/templates/deployment.yaml
+++ b/charts/legalhold/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .Release.Name }}-hold"
+  labels:
+    name: "{{ .Release.Name }}-hold"
+  annotations:
+    checksum/secret-token: {{ include (print .Template.BasePath "/secret-token.yaml") . | sha256sum }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: "{{ .Release.Name }}-hold"
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-hold"
+      labels:
+        name: "{{ .Release.Name }}-hold"
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: hold
+          image: quay.io/wire/legalhold:1.0.2
+          imagePullPolicy: IfNotPresent
+
+          resources:
+            requests:
+              memory: "1500Mi"
+              cpu: 50m
+            limits:
+              memory: "1500Mi"
+
+          env:
+            - name: LD_LIBRARY_PATH
+              value: /opt/wire/lib
+
+            - name: WIRE_API_HOST
+              value: "{{ required "Must specify wireApiHost" .Values.wireApiHost }}"
+
+            - name: DELAY
+              value: 15s
+
+            - name: SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-hold-token"
+                  key: token
+
+            - name: DB_URL
+              value: "jdbc:postgresql://{{ .Release.Name }}-postgresql/postgres"
+
+            - name: DB_USER
+              value: postgres
+
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-postgresql"
+                  key: postgresql-password
+
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8081
+              protocol: TCP
+            - containerPort: 8082
+              protocol: TCP
+
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+
+          # for L7 LB
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10

--- a/charts/legalhold/templates/ingress.yaml
+++ b/charts/legalhold/templates/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: hold
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  # This assumes you have created the given cert
+  # https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/PREREQUISITES.md#tls-certificates
+  tls:
+  - hosts:
+      - "{{ required  "Must specify host" .Values.host }}"
+    secretName: "{{ .Release.Name }}-hold-tls"
+  rules:
+    - host: "{{ .Values.host }}"
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: "{{ .Release.Name }}-hold"
+              servicePort: 8080

--- a/charts/legalhold/templates/secret-tls.yaml
+++ b/charts/legalhold/templates/secret-tls.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-hold-tls"
+type: kubernetes.io/tls
+data:
+  tls.crt: "{{ required "Must specify tlsCrt" .Values.tlsCrt | b64enc }}"
+  tls.key: "{{ required "Must specify tlsKey" .Values.tlsKey | b64enc }}"

--- a/charts/legalhold/templates/secret-token.yaml
+++ b/charts/legalhold/templates/secret-token.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-hold-token"
+type: Opaque
+data:
+  token: "{{ required "Must specify serviceToken" .Values.serviceToken | b64enc }}"

--- a/charts/legalhold/templates/service.yaml
+++ b/charts/legalhold/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-hold"
+spec:
+  type: ClusterIP
+  selector:
+    name: "{{ .Release.Name }}-hold"
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/charts/legalhold/values.yaml
+++ b/charts/legalhold/values.yaml
@@ -1,0 +1,15 @@
+# The public domain name on which legalhold is hosted
+# host: ""
+
+# The TLS private key
+# tlsKey: ""
+
+# The certificate and for the legalhold service. Must be a valid
+# certificate  or .Values.host
+# tlsCrt: ""
+
+# The public URI on which Wire is reachable
+# wireApiHost: ""
+
+# The shared secret that the backend uses to authenticate to legalhold
+# serviceToken: ""

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -90,3 +90,9 @@ dependencies:
     - web
     - account-pages
     - private
+- name: legalhold
+  version: "0.124.0"
+  repository: "file://../legalhold"
+  tags:
+    - legalhold
+    - private

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -8,3 +8,4 @@
 tags:
   team-settings: false
   account-pages: false
+  legalhold: false

--- a/values/wire-server/prod-secrets.example.yaml
+++ b/values/wire-server/prod-secrets.example.yaml
@@ -63,7 +63,24 @@ nginz:
     # only necessary in test environments (env="staging"). See charts/nginz/README.md
     basicAuth: "<username>:<htpasswd-hashed-password>"
 
-team-settings:
-  secrets:
-    # Required if you want to use team-settings
-    configJson:
+# Uncomment for team-settings. Set values accordingly
+
+# team-settings:
+#   secrets:
+#     # Required if you want to use team-settings
+#     configJson: "b64 string you got from us"
+
+# Uncomment for legalhold. Set values accordingly
+
+# legalhold:
+#   serviceToken: "supersecret"
+#   # openssl req -x509 -newkey rsa:4096 -sha256 -keyout tls.key -out tls.crt -days
+#   # 365 -subj '/CN={{ .Values.legalhold.host }}' Or provide your own signed by a
+#   # proper CA
+#   tlsKey: |
+#     -----BEGIN PRIVATE KEY-----
+#     -----END PRIVATE KEY-----
+#
+#   tlsCrt: |
+#     -----BEGIN CERTIFICATE-----
+#     -----END CERTIFICATE-----

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -1,6 +1,9 @@
 # CHANGEME-PROD: All values here should be changed/reviewed
 tags:
   proxy: false # enable if you want/need giphy/youtube/etc proxying
+  account-pages: true
+  team-settings: false # enable if you need team-settings. Requires a pullSecret
+  legalhold: false # Enable if you need legalhold
 
 cassandra-migrations:
 #  images:
@@ -64,10 +67,10 @@ brig:
       host: demo-smtp # change this if you want to use your own SMTP server
       port: 25        # change this
       connType: plain # change this. Possible values: plain|ssl|tls
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
   turnStatic:
@@ -87,10 +90,10 @@ proxy:
 #  image:
 #    tag: some-tag (only override if you want a newer/different version than what is in the chart)
 #  config:
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -112,10 +115,10 @@ cargohold:
       s3Bucket: assets
       s3Endpoint: http://minio-external:9000
       s3DownloadEndpoint: https://assets.example.com
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -132,14 +135,16 @@ galley:
       # see #RefConfigOptions in `/docs/reference` (https://github.com/wireapp/wire-server/)
       featureFlags:
         sso: disabled-by-default
-        legalhold: disabled-by-default
+        # NOTE: Change this to "disabled-by-default" for legalhold support
+        # legalhold: disabled-by-default
+        legalhold: disabled-permanently
         teamSearchVisibility: disabled-by-default
     aws:
       region: "eu-west-1"
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -158,10 +163,10 @@ gundeck:
       queueName: integration-gundeck-events
       sqsEndpoint: http://fake-aws-sqs:4568
       snsEndpoint: http://fake-aws-sns:4575
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -199,10 +204,10 @@ spar:
     - type: ContactSupport
       company: YourCompany
       email: email:support@example.com
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -267,6 +272,8 @@ team-settings:
     FEATURE_CHECK_CONSENT: "false"
     FEATURE_ENABLE_DEBUG: "false"
     FEATURE_ENABLE_NEW_TEAM: "true"
+    # NOTE: Uncomment this for legalhold support in the Team-settings UI
+    # FEATURE_ENABLE_LEGAL_HOLD: "true"
     URL_ACCOUNT_BASE: "https://account.example.com"
     URL_WEBAPP_BASE: "https://webapp.example.com"
     URL_WEBSITE_BASE: "https://www.example.com"
@@ -315,3 +322,8 @@ account-pages:
     CSP_EXTRA_PREFETCH_SRC: "https://*.example.com"
     CSP_EXTRA_STYLE_SRC: "https://*.example.com"
     CSP_EXTRA_WORKER_SRC: "https://*.example.com"
+
+# Only needed when legalhold is enabled
+legalhold:
+  host: "legalhold.example.com"
+  wireApiHost: "https://nginz-https.example.com"


### PR DESCRIPTION
A chart to install the legalhold service on-prem.

This assumes a storage provisioner is present on the cluster that
provisions volumes of storageClass: local-path

We recommend https://github.com/rancher/local-path-provisioner/tree/master/deploy/chart
which we will add in an upcoming commit