### PR TITLE
experiment: Highly available SFTD in kubernetes

### DIFF
--- a/manifests/sftd/README.md
+++ b/manifests/sftd/README.md
@@ -1,0 +1,95 @@
+# SFTD on kubernetes
+
+## Preparing nodes in your cluster to host sftd
+
+The sftd component is a bit special compared to other wire services, in that it
+needs access to the host network. This is because it allocates UDP ports on
+your public interface so that people can set up calls with the SFT.
+
+Not all your nodes in your cluster might have a public IP. Currently the code
+is set up such that the sftd components only run on nodes that have been
+labelled to support it.
+
+Within one sftd deployment, kubernetes will make sure that no two sftd pods
+will run on the same node to avoid port allocation conflicts.
+
+However, kubernetes can not guarantee that two _separate_ sftd deployments (for
+example staging and prod) are not scheduled on the same node.  It is thus
+important that if you have multiple sftd deployments that they run on a
+disjoint set of nodes.
+
+In our example we have two environments, `staging` and `prod`.  And thus we
+create create node groups.
+
+```
+kubectl label node node-0 wire.com/role=sftd-prod
+kubectl label node node-1 wire.com/role=sftd-prod
+kubectl label node node-2 wire.com/role=sftd-prod
+
+kubectl label node node-3 wire.com/role=sftd-staging
+kubectl label node node-4 wire.com/role=sftd-staging
+```
+
+If you look in `overlays/prod/statefulset.yaml` you see that we configure `sftd` to
+only run on nodes with label `wire.com/role=sftd-prod`. Similarly for the `overlays/staging` setup.
+```
+...
+      nodeSelector:
+        wire.com/role: sftd-prod
+...
+```
+
+## Configuring SFTD
+
+### Ingress
+
+in `overlays/{prod,staging}/ingress.yaml` you should set the domain name on
+which `sftd`'s https API shoud be reachable for clients by setting the
+`wire.com/ingress-host` annotation on the `Ingress`
+
+### Certificates
+
+If you have cert-manager running in your cluster, this example will
+automatically issue certificates for the SFT.  You should make sure that
+the `cert-manager.io/cluster-issuer` matches the name of the `ClusterIssuer` that
+you have deployed in your cluster.
+
+You can remove automatic certificate issuance by removing the
+`cert-manager.io/cluster-issuer` annotation from the `Ingress` completely.  You
+should then provide your own TLS certificate manually. You can do this by
+adding the following section to the environment's `kustomization.yaml`:
+```yaml
+secretGenerator:
+  - name: sftd-tls
+    type: kubernetes.io/tls
+    files:
+      - path/to/tls.crt
+      - path/to/tls.key
+```
+
+## Replicas and resources
+You should make sure that the number of replicas on the `sftd` statefulset is
+not more than the amount of nodes with the `sftd` role.  Only one `sftd` pod
+can be scheduled per node.
+
+Resource limits can be set on a per-environment basis too. We do not have
+recommended values for these yet so we leave them unset for now.
+
+# Deploy
+
+Once you have configured everything a deploy can simply be done with `kubectl`:
+
+For staging:
+```
+$ kubectl apply -k ./overlays/staging
+```
+
+For prod:
+```
+$ kubectl apply -k ./overlays/prod
+```
+
+To delete the deployment:
+```
+kubectl delete -k ./overlays/staging
+```

--- a/manifests/sftd/README.md
+++ b/manifests/sftd/README.md
@@ -23,23 +23,32 @@ create create node groups.
 
 
 ```
-kubectl label node node-0 wire.com/role=sftd-prod
-kubectl label node node-1 wire.com/role=sftd-prod
-kubectl label node node-2 wire.com/role=sftd-prod
+kubectl label node kubenode0 wire.com/role=sftd-prod
+kubectl label node kubenode1 wire.com/role=sftd-prod
+kubectl label node kubenode2 wire.com/role=sftd-prod
 
-kubectl label node node-3 wire.com/role=sftd-staging
-kubectl label node node-4 wire.com/role=sftd-staging
+kubectl label node kubenode3 wire.com/role=sftd-staging
+kubectl label node kubenode4 wire.com/role=sftd-staging
 ```
 
 Or set them in your [ansible inventory](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/vars.md#other-service-variables):
 
 ```
-node-0 node_labels="wire.com/role=sftd-prod"
-node-1 node_labels="wire.com/role=sftd-prod"
-node-2 node_labels="wire.com/role=sftd-prod"
+[sftd-prod]
+kubenode0
+kubenode1
+kubenode2
 
-node-3 node_labels="wire.com/role=sftd-staging"
-node-4 node_labels="wire.com/role=sftd-staging"
+[sftd-staging]
+kubenode3
+kubenode4
+
+[sftd-prod:vars]
+node_labels="wire.com/role=sftd-prod"
+
+[sftd-staging:vars]
+node_labels="wire.com/role=sftd-staging"
+
 ```
 
 If you look in `overlays/prod/statefulset.yaml` you see that we configure `sftd` to

--- a/manifests/sftd/README.md
+++ b/manifests/sftd/README.md
@@ -21,6 +21,7 @@ disjoint set of nodes.
 In our example we have two environments, `staging` and `prod`.  And thus we
 create create node groups.
 
+
 ```
 kubectl label node node-0 wire.com/role=sftd-prod
 kubectl label node node-1 wire.com/role=sftd-prod
@@ -28,6 +29,17 @@ kubectl label node node-2 wire.com/role=sftd-prod
 
 kubectl label node node-3 wire.com/role=sftd-staging
 kubectl label node node-4 wire.com/role=sftd-staging
+```
+
+Or set them in your [ansible inventory](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/vars.md#other-service-variables):
+
+```
+node-0 node_labels="wire.com/role=sftd-prod"
+node-1 node_labels="wire.com/role=sftd-prod"
+node-2 node_labels="wire.com/role=sftd-prod"
+
+node-3 node_labels="wire.com/role=sftd-staging"
+node-4 node_labels="wire.com/role=sftd-staging"
 ```
 
 If you look in `overlays/prod/statefulset.yaml` you see that we configure `sftd` to

--- a/manifests/sftd/base/default.conf.template
+++ b/manifests/sftd/base/default.conf.template
@@ -1,0 +1,22 @@
+server {
+  listen 80;
+  listen [::]:80;
+
+
+  # This is only because nginx is insane and doesn't use nss and also doesn't
+  # parse /etc/resolv.conf Because of this it doesn't know about the pod's
+  # namespace (that's usually in the search entry on resolv.conf) so we pass
+  # that in as an environment variable
+  resolver kube-dns.kube-system.svc.cluster.local;
+
+
+  # initiate call. Use round-robin to assign an sft randomly
+  location / {
+    proxy_pass http://sftd.${POD_NAMESPACE}.svc.cluster.local;
+  }
+
+  # join existing call by directly contacting the pod
+  location ~ ^/([a-z0-9\-]+)/(.*)$ {
+    proxy_pass http://$1.sftd-headless.${POD_NAMESPACE}.svc.cluster.local:8585/$2;
+  }
+}

--- a/manifests/sftd/base/deployment-lb.yaml
+++ b/manifests/sftd/base/deployment-lb.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sftd-lb
+spec:
+  selector:
+    matchLabels:
+      app: sftd-lb
+  template:
+    metadata:
+      labels:
+        app: sftd-lb
+    spec:
+      volumes:
+        - name: sftd-nginx-lb-config
+          configMap:
+            name: sftd-nginx-lb-config
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d/default.conf.template
+              name: sftd-nginx-lb-config
+              subPath: default.conf.template
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              envsubst \${POD_NAMESPACE} < /etc/nginx/conf.d/default.conf.template | tee /dev/stderr > /etc/nginx/conf.d/default.conf
+              exec nginx -g 'daemon off;'
+

--- a/manifests/sftd/base/ingress.yaml
+++ b/manifests/sftd/base/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sftd
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  tls:
+  - hosts:
+    - $(SFTD_INGRESS_HOST)
+    secretName: sftd-tls
+  rules:
+  - host: $(SFTD_INGRESS_HOST)
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: sftd-lb
+            servicePort: 80

--- a/manifests/sftd/base/kustomization.yaml
+++ b/manifests/sftd/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service-sftd.yaml
+  - service-sftd-headless.yaml
+  - service-lb.yaml
+  - statefulset-sftd.yaml
+  - deployment-lb.yaml
+  - ingress.yaml
+configMapGenerator:
+  - name: sftd-nginx-lb-config
+    files:
+      - default.conf.template
+vars:
+  - name: SFTD_INGRESS_HOST
+    objRef:
+      apiVersion: networking.k8s.io/v1beta1
+      kind: Ingress
+      name: sftd
+    fieldRef:
+      fieldPath: metadata.annotations["wire.com/ingress-host"]

--- a/manifests/sftd/base/service-lb.yaml
+++ b/manifests/sftd/base/service-lb.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sftd-lb
+spec:
+  selector:
+    app: sftd-lb
+  ports:
+  - port: 80
+    targetPort: 80

--- a/manifests/sftd/base/service-sftd-headless.yaml
+++ b/manifests/sftd/base/service-sftd-headless.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sftd-headless
+spec:
+  clusterIP: None
+  selector:
+    app: sftd
+  ports:
+  - port: 80
+    targetPort: 8585
+

--- a/manifests/sftd/base/service-sftd.yaml
+++ b/manifests/sftd/base/service-sftd.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sftd
+spec:
+  selector:
+    app: sftd
+  ports:
+  - port: 80
+    targetPort: 8585

--- a/manifests/sftd/base/statefulset-sftd.yaml
+++ b/manifests/sftd/base/statefulset-sftd.yaml
@@ -1,0 +1,63 @@
+# we _need_ a statefulset because we never want more pods than replicas, even
+# during roll-outs as due to hostNetwork they'll surged pods will be
+# unschedulable due to port binding conflict
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sftd
+spec:
+  serviceName: sftd-headless
+  selector:
+    matchLabels:
+      app: sftd
+  template:
+    metadata:
+      labels:
+        app: sftd
+    spec:
+      hostNetwork: true
+      volumes:
+        - name: external-ip
+          emptyDir: {}
+      initContainers:
+        - name: external-ip
+          image: alpine
+          volumeMounts:
+            - mountPath: /external-ip
+              name: external-ip
+          command:
+            - /bin/sh
+            - -c
+            - |
+                set -e
+                # TODO: Re-add the get-external-ip logic? So this at least works on GKE
+                # requires us to set up a service-account
+                external_ip=$(ip route get 1 | awk '{print $7;exit}')
+                echo $external_ip
+                echo "export EXTERNAL_IP=$external_ip" >> /external-ip/env
+
+      containers:
+        - name: sftd
+          image: quay.io/wire/sftd
+          volumeMounts:
+            - mountPath: /external-ip
+              name: external-ip
+          ports:
+            - containerPort: 8585
+              name: sft
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command:
+            - /bin/sh
+            - -c
+            - |
+                set -e
+                . /external-ip/env
+                exec sftd -I $POD_IP -M $POD_IP -A $EXTERNAL_IP -u https://$(SFTD_INGRESS_HOST)/$POD_NAME

--- a/manifests/sftd/overlays/prod/ingress.yaml
+++ b/manifests/sftd/overlays/prod/ingress.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sftd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    wire.com/ingress-host: sftd-prod.k8s.arianvp.me

--- a/manifests/sftd/overlays/prod/kustomization.yaml
+++ b/manifests/sftd/overlays/prod/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+namespace: sftd-prod
+bases:
+  - ../../base
+patchesStrategicMerge:
+  - statefulset.yaml
+  - ingress.yaml
+
+# Uncomment when not using cert-manager, and you have certificates on disk you
+# want to use instead
+# secretGenerator:
+#   - name: sftd-tls
+#     type: kubernetes.io/tls
+#     files:
+#       - tls.crt
+#       - tls.key

--- a/manifests/sftd/overlays/prod/namespace.yaml
+++ b/manifests/sftd/overlays/prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod

--- a/manifests/sftd/overlays/prod/statefulset.yaml
+++ b/manifests/sftd/overlays/prod/statefulset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sftd
+spec:
+  # Should be less or requal to the number of nodes
+  replicas: 3
+  template:
+    spec:
+      # sftd statefulset requires hostNetwork and needs a public IP.  You
+      # can use nodeSelector to only schedule sftd on nodes that fulfill
+      # these requirements
+      nodeSelector:
+        wire.com/role: sftd-prod
+      containers:
+        - name: sftd
+          resources:
+            requests:
+              cpu: 250m
+              memory: 100Mi
+
+

--- a/manifests/sftd/overlays/staging/ingress.yaml
+++ b/manifests/sftd/overlays/staging/ingress.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sftd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    wire.com/ingress-host: sftd-staging.k8s.arianvp.me

--- a/manifests/sftd/overlays/staging/kustomization.yaml
+++ b/manifests/sftd/overlays/staging/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+resources:
+  - namespace.yaml
+namespace: staging
+patchesStrategicMerge:
+  - ingress.yaml
+  - statefulset.yaml
+images:
+  - digest: sha256:6b1daa9462046581ac15be20277a7c75476283f969cb3a61c8725ec38d3b01c3
+    name: nginx
+# Uncomment when not using cert-manager, and you have certificates on disk you
+# want to use instead
+# secretGenerator:
+#   - name: sftd-tls
+#     type: kubernetes.io/tls
+#     files:
+#       - tls.crt
+#       - tls.key

--- a/manifests/sftd/overlays/staging/namespace.yaml
+++ b/manifests/sftd/overlays/staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging

--- a/manifests/sftd/overlays/staging/statefulset.yaml
+++ b/manifests/sftd/overlays/staging/statefulset.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sftd
+spec:
+  replicas: 2
+  template:
+    spec:
+      # Makes sure these pods are only scheduled on specific sftd nodes.  the
+      # pods run in the hostNetwork; so we for example do not want staging and
+      # prod to mix; as there will be port conflicts and scheduling will be
+      # impossible.
+      nodeSelector:
+        wire.com/role: sftd-staging
+


### PR DESCRIPTION
This implements the proposal in https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/150930455/SFT+Load+balancing

Not packed up as a helm chart, but uses kubectl's built-in `kustomize`
functionality for making configs configurable.

Happy to convert this back to helm if we find this better for external
consumption but I wanted to try out this kustomize thing.

fixes https://github.com/zinfra/backend-issues/issues/1699
fixes https://github.com/zinfra/backend-issues/issues/1704
fixes https://github.com/zinfra/backend-issues/issues/1801


If we migrate our prod `sftd` to kubernetes:
fixes https://github.com/zinfra/backend-issues/issues/1796 (as it removes SRV announcer)
maybe fixes https://github.com/zinfra/backend-issues/issues/1563 if we reuse fluent-bit for log aggregation
maybe fixes https://github.com/zinfra/backend-issues/issues/1791 (As we use kubernetes service discovery for prometheus)
maybe fixes https://github.com/zinfra/backend-issues/issues/1728 (We can reuse kubernetes audit logs)

