### PR TITLE
chrats/nginx-ingress-services: Fix invalid ObjectMeta

### DIFF
--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -4,7 +4,6 @@ kind: Certificate
 metadata:
   name: "{{ include "nginx-ingress-services.zone" . | replace "." "-" }}-csr"
   namespace: {{ .Release.Namespace }}
-  docs: "https://cert-manager.io/docs/usage/certificate"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -4,7 +4,6 @@ kind: Issuer
 metadata:
   name: letsencrypt-http01
   namespace: {{ .Release.Namespace }}
-  docs: "https://cert-manager.io/docs/configuration/acme/"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"


### PR DESCRIPTION
docs is not a valid components in ObjectMeta.  These objects wouldn't
apply without these changes

Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Certificate.metadat
a): unknown field "docs" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta


Ran into this whilst trying to apply this chart on my own kubernetes cluster which had cert-manager preinstalled