### PR TITLE
[ansible] Add quoting to manual log "aggregation"

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -70,8 +70,8 @@ endif
 		--private-key ${ENV_DIR}/operator-ssh.dec \
 		--extra-vars "log_host=${LOG_HOST}" \
 		--extra-vars "log_service=${LOG_SERVICE}" \
-		--extra-vars "log_since=${LOG_SINCE}" \
-		--extra-vars "log_until=${LOG_UNTIL}" \
+		--extra-vars "log_since='${LOG_SINCE}'" \
+		--extra-vars "log_until='${LOG_UNTIL}'" \
 		--extra-vars "log_dir=${LOG_DIR}"
 
 .PHONY: ensure-env-dir

--- a/ansible/get-logs.yml
+++ b/ansible/get-logs.yml
@@ -1,7 +1,7 @@
 - hosts: "{{ log_host }}"
   tasks:
     - name: get logs
-      shell: journalctl -u {{ log_service }} --since {{ log_since }} --until {{ log_until }}
+      shell: journalctl -u {{ log_service }} --since '{{ log_since }}' --until '{{ log_until }}'
       register: the_logs
     - name: create logs directory
       delegate_to: localhost


### PR DESCRIPTION
to allow defining hour-based time constraints. A corresponding
invocations would look like:

```bash
  make get-logs ENV=prod \
                LOG_HOST=prod-sft-13 \
                LOG_SERVICE=sft-server \
                LOG_SINCE="2020-12-07 11:00:00" \
                LOG_UNTIL="2020-12-07 12:00:00" \
                LOG_DIR="./"
```