### PR TITLE
charts: Move to helm stable repo snapshot

### DIFF
--- a/charts/cassandra-ephemeral/requirements.yaml
+++ b/charts/cassandra-ephemeral/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: cassandra
   version: 0.13.3
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com
+  repository: https://charts.helm.sh/incubator
   alias: cassandra-ephemeral

--- a/charts/elasticsearch-curator/requirements.yaml
+++ b/charts/elasticsearch-curator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: elasticsearch-curator
   version: 1.5.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/fluent-bit/requirements.yaml
+++ b/charts/fluent-bit/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: fluent-bit
   version: 2.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/kibana/requirements.yaml
+++ b/charts/kibana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: kibana
   version: 2.2.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/metallb/requirements.yaml
+++ b/charts/metallb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: metallb
   version: 0.8.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
   version: 1.33.3
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable


### PR DESCRIPTION
The stable repo has been deprecated and snapshotted
https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository

We should move away from these charts in the near future; but moving to
the snapshot suffices for now