### PR TITLE
Release 2020 12 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# NEXT
+
+A new mandatory option has been introduced to
+`brig` and `galley` which in the future will be used for Wire federation.  This domain name
+is *not* optional even if federation is not used.
+
+Please update your `values/wire-server/values.yaml` to set `brig.optSettings.setFederationDomain`
+and `galley.settings.federationDomain` (Note the slightly different option name).
+
+**NOTE**: These changes apply to chart version **0.129.0** and later eventhough
+this release was made later than that **0.129.0** chart was published. We're sorry for the
+inconvenience.
+
 # 2020-12-07
 
 ## Update instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# NEXT
+# 2020-12-17
 
+## Update instructions
 A new mandatory option has been introduced to
 `brig` and `galley` which in the future will be used for Wire federation.  This domain name
 is *not* optional even if federation is not used.
@@ -7,9 +8,16 @@ is *not* optional even if federation is not used.
 Please update your `values/wire-server/values.yaml` to set `brig.optSettings.setFederationDomain`
 and `galley.settings.federationDomain` (Note the slightly different option name).
 
+Because federation is not enabled yet the value of this option does not really
+matter at this point, but we advise you to set it to the base domain of your
+wire instalation.
+
 **NOTE**: These changes apply to chart version **0.129.0** and later eventhough
 this release was made later than that **0.129.0** chart was published. We're sorry for the
 inconvenience.
+
+## Features
+* A chart has been added for setting up a single-node conferencing server (Also known as *SFT*) (#382)
 
 # 2020-12-07
 

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -70,8 +70,8 @@ endif
 		--private-key ${ENV_DIR}/operator-ssh.dec \
 		--extra-vars "log_host=${LOG_HOST}" \
 		--extra-vars "log_service=${LOG_SERVICE}" \
-		--extra-vars "log_since=${LOG_SINCE}" \
-		--extra-vars "log_until=${LOG_UNTIL}" \
+		--extra-vars "log_since='${LOG_SINCE}'" \
+		--extra-vars "log_until='${LOG_UNTIL}'" \
 		--extra-vars "log_dir=${LOG_DIR}"
 
 .PHONY: ensure-env-dir

--- a/ansible/get-logs.yml
+++ b/ansible/get-logs.yml
@@ -1,7 +1,7 @@
 - hosts: "{{ log_host }}"
   tasks:
     - name: get logs
-      shell: journalctl -u {{ log_service }} --since {{ log_since }} --until {{ log_until }}
+      shell: journalctl -u {{ log_service }} --since '{{ log_since }}' --until '{{ log_until }}'
       register: the_logs
     - name: create logs directory
       delegate_to: localhost

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -8,4 +8,11 @@
   roles:
     - etcd-helpers
 
+- hosts: k8s-cluster
+  tasks:
+    - name: Annotate nodes
+      command: "kubectl annotate node --overwrite {{ inventory_hostname }} {{ item.key }}={{ item.value }}"
+      when: node_annotations is defined
+      with_dict: node_annotations
+
 - import_playbook: kubernetes_logging.yml

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -207,5 +207,8 @@ data:
       setCustomerExtensions:
         domainsBlockedForRegistration: {{ .setCustomerExtensions.domainsBlockedForRegistration }}
       {{- end }}
+      {{- if .setSftStaticUrl }}
+      setSftStaticUrl: {{ .setSftStaticUrl }}
+      {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/cassandra-ephemeral/requirements.yaml
+++ b/charts/cassandra-ephemeral/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: cassandra
   version: 0.13.3
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com
+  repository: https://charts.helm.sh/incubator
   alias: cassandra-ephemeral

--- a/charts/elasticsearch-curator/requirements.yaml
+++ b/charts/elasticsearch-curator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: elasticsearch-curator
   version: 1.5.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/fluent-bit/requirements.yaml
+++ b/charts/fluent-bit/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: fluent-bit
   version: 2.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/kibana/requirements.yaml
+++ b/charts/kibana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: kibana
   version: 2.2.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/metallb/requirements.yaml
+++ b/charts/metallb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: metallb
   version: 0.8.0
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
   version: 1.33.3
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -80,6 +80,14 @@ nginx_conf:
       envs:
       - all
       doc: true
+    - path: ~* ^/api/swagger.json$
+      disable_zauth: true
+      envs:
+      - all
+    - path: /api/swagger-ui
+      disable_zauth: true
+      envs:
+      - all
     - path: /self
       envs:
       - all

--- a/charts/sftd/Chart.yaml
+++ b/charts/sftd/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: sftd
+description: SFTD is a component for engaging in conference calls
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.124.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.88

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -1,0 +1,112 @@
+# SFTD Chart
+
+## Deploy
+
+Replace `example.com` with your own domain here.
+
+Using your own certificates:
+
+```
+helm install sftd wire/sftd  \
+  --set host=sftd.example.com \
+  --set allowOrigin=https://webapp.example.com \
+  --set-file tls.crt=/path/to/tls.crt \
+  --set-file tls.key=/path/to/tls.key
+```
+
+Using Cert-manager:
+```
+helm install sftd wire/sftd \
+  --set host=example.com \
+  --set allowOrigin=https://webapp.example.com \
+  --set tls.issuerRef.name=letsencrypt-staging
+```
+
+the `host` option will be used to set up an `Ingress` object.
+
+The domain in `host` must point to the public IP you have deployed to handle
+incoming traffic to your cluster. This is environment-specific.
+
+You can switch between `cert-manager` and own-provided certificates at any
+time. Helm will delete the `sftd` secret automatically and then cert-manager
+will create it instead.
+
+It is important that `allowOrigin` is synced with the domain where the web app is hosted
+as configured in the `wire-server` chart or the webapp will not be able to contact the SFT
+server.
+
+You should configure `brig` to hand out the SFT server to clients by setting
+`brig.optSettings.setSftStaticUrl=https://sftd.example.com:443` on the `wire-server` chart
+
+
+## Multiple sftd deployments in a single cluster
+Because sftd uses the `hostNetwork` and binds to the public IP of the node,
+there can only be one `sftd` pod running per node in the cluster.  Within a
+single `StatefulSet` kubernetes will make sure no two pods are scheduled on the
+same machine automatically. However, if you have multiple `sftd` deployments under
+different releases names or in a different namespace more care has to be taken.
+
+You can set the `nodeSelector` option; to make sure your sftd releases run on disjoint sets of nodes.
+
+For example, consider the following inventory of nodes, where there are two groups
+annotated with
+
+```
+[sftd-prod:vars]
+node_labels="wire.com/role=sftd-prod"
+[sftd-staging:vars]
+node_labels="wire.com/role=sftd-staging"
+
+[sftd-prod]
+node0
+node1
+node3
+
+[sftd-staging]
+node4
+```
+
+Then we can make two `sftd` deployments and make sure Kubernetes schedules them on distinct set of nodes:
+
+```
+helm install sftd-prod charts/sftd    --set 'nodeSelector.wire\.com/role=sftd-prod' ...other-flags
+helm install sftd-staging charts/sftd --set 'nodeSelector.wire\.com/role=sftd-staging' ...other-flags
+```
+
+## No public IP on default interface
+
+Often on-prem or at certain cloud providers your nodes will not have directly routable public IP addresses
+but are deployed in 1:1 NAT.   This chart is able to auto-detect this scenario if your cloud providers adds
+an `ExternalIP` field to your kubernetes node objects.
+
+On on-prem you should set an `wire.com/external-ip` annotation on your kubernetes nodes so that sftd is aware
+of its external IP when it gets scheduled on a node.
+
+If you use our kubespray playbooks to bootstrap kubernetes, you simply have to
+set the `external_ip` field in your `group_vars`
+```yaml
+# inventory/group_vars/k8s-cluster
+node_annotations:
+  wire.com/external-ip: {{ external_ip }}
+```
+And the `external_ip` is set in the inventory per node:
+```
+node0 ansible_host=.... ip=...  external_ip=aaa.xxx.yyy.zzz
+```
+
+If you are hosting Kubernetes through other means you can annotate your nodes manually:
+```
+$ kubectl annotate node $HOSTNAME wire.com/external-ip=$EXTERNAL_IP
+```
+
+## Port conflicts and `hostNetwork`
+
+Kubernetes by default allocates node ports in the `30000-32768` range. This can
+be adjusted with the `--service-nodeport-range` flag.
+https://kubernetes.io/docs/concepts/services-networking/service/ SFTD asks the
+kernel for free ports, which by default are in the `32768-61000` range
+(https://ma.ttias.be/linux-increase-ip_local_port_range-tcp-port-range/).
+
+On a default installation these ranges do not overlap and sftd should never have
+conflicts with kubernetes components. You should however check that on your OS
+these ranges aren't configured differently.

--- a/charts/sftd/templates/_helpers.tpl
+++ b/charts/sftd/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sftd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sftd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sftd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sftd.labels" -}}
+helm.sh/chart: {{ include "sftd.chart" . }}
+{{ include "sftd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sftd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sftd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/sftd/templates/ingress.yaml
+++ b/charts/sftd/templates/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ include "sftd.fullname" . }}"
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "{{ required "Must specify allowOrigin" .Values.allowOrigin }}"
+spec:
+  tls:
+  - hosts:
+      - "{{ required  "Must specify host" .Values.host }}"
+    secretName: "{{ include "sftd.fullname" . }}"
+  rules:
+    - host: "{{ .Values.host }}"
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: "{{ include "sftd.fullname" . }}"
+              servicePort: sft

--- a/charts/sftd/templates/secret-or-certificate.yaml
+++ b/charts/sftd/templates/secret-or-certificate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.tls.issuerRef -}}
+{{- if or .Values.tls.key  .Values.tls.crt }}
+{{- fail "ingress.issuer and  ingress.{crt,key} are mutually exclusive" -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include "sftd.fullname" . }}"
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ .Values.host }}
+  secretName: "{{ include "sftd.fullname" . }}"
+  issuerRef:
+    {{- toYaml .Values.tls.issuerRef | nindent 4 }}
+  privateKey:
+    rotationPolicy: Always
+    algorithm: ECDSA
+    size: 384
+{{- else if and .Values.tls.key .Values.tls.crt  -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "sftd.fullname" . }}"
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.key: {{ required "tls.key is required" .Values.tls.key | b64enc }}
+  tls.crt: {{ required "tls.crt is required" .Values.tls.crt | b64enc }}
+{{- else -}}
+{{- fail "must specify tls.key and tls.crt , or tls.issuerRef" -}}
+{{- end -}}

--- a/charts/sftd/templates/service-account.yaml
+++ b/charts/sftd/templates/service-account.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sftd.fullname" . }}
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sftd.fullname" . }}
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sftd.fullname" . }}
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "sftd.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sftd.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/sftd/templates/service.yaml
+++ b/charts/sftd/templates/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sftd.fullname" . }}
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+spec:
+  # Needs to be headless
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+  clusterIP: None
+  ports:
+    - port: 8585
+      targetPort: sft
+      name: sft
+    - port: 49090
+      targetPort: metrics
+      name: metrics
+  selector:
+    {{- include "sftd.selectorLabels" . | nindent 4 }}

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sftd.fullname" . }}
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+spec:
+  # TODO: Make configurable in follow-up PR
+  # This is 1 on purpose as we need more machinery to make multiple SFTs work.
+  # Work for that is tracked in: https://github.com/wireapp/wire-server-deploy/pull/383
+  replicas: 1
+  serviceName: {{ include "sftd.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "sftd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "sftd.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      hostNetwork: true
+      serviceAccountName: {{ include "sftd.fullname" . }}
+      volumes:
+        - name: external-ip
+          emptyDir: {}
+      initContainers:
+        - name: get-external-ip
+          image: bitnami/kubectl
+          volumeMounts:
+            - name: external-ip
+              mountPath: /external-ip
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              # In the cloud, this setting is available to indicate the true IP address
+              addr=$(kubectl get node $HOSTNAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+
+              # On on-prem we allow people to set  "wire.com/external-ip" to override this
+              if [ -z "$addr" ]; then
+                addr=$(kubectl get node $HOSTNAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+              fi
+              echo -n "$addr" | tee /dev/stderr > /external-ip/ip
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: external-ip
+              mountPath: /external-ip
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              EXTERNAL_IP=$(cat /external-ip/ip)
+              if [ -z "${EXTERNAL_IP}" ]; then
+                ACCESS_ARGS=
+              else
+                ACCESS_ARGS="-A ${EXTERNAL_IP}"
+              fi
+              exec sftd  -I "${POD_IP}" -M "${POD_IP}" ${ACCESS_ARGS} -u "https://{{ required "must specify host" .Values.host }}"
+          ports:
+            - name: sft
+              containerPort: 8585
+              protocol: TCP
+            - name: metrics
+              containerPort: 49090
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          lifecycle:
+            preStop:
+              exec:
+                # TODO: Workaround because sftd does not support graceful draining natively.
+                # tracked in https://github.com/zinfra/backend-issues/issues/1451
+                command:
+                  - /bin/sleep
+                  - "{{ .Values.terminationGracePeriodSeconds }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -1,0 +1,69 @@
+# Default values for sftd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: quay.io/wire/sftd
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# The time to wait after terminating an sft node before shutting it down. No
+# new calls will be initiated whilst a pod is terminated. This value will be
+# more useful once we support running multiple sfts behind a load-balancer
+terminationGracePeriodSeconds: 10
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 31337
+
+securityContext:
+  # Pick a high number that is unlikely to conflict with the host
+  # https://kubesec.io/basics/containers-securitycontext-runasuser/
+  runAsUser: 31337
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# If you have multiple deployments of sftd running in one cluster, it is
+# important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# allowOrigin:  https://webapp.example.com
+# host:
+tls: {}
+  # {key,crt} and issuerRef are mutally exclusive
+  # key:
+  # crt:
+  # issuerRef:
+    # The name of the issuer (e.g. letsencrypr-prod)
+    # name: ca-issuer
+    # We can reference ClusterIssuers by changing the kind here.
+    # The default value is Issuer (i.e. a locally namespaced Issuer)
+    # kind: Issuer
+    # This is optional since cert-manager will default to this value however
+    # if you are using an external issuer, change this to that issuer group.
+    # group: cert-manager.io

--- a/charts/wire-server-metrics/requirements.yaml
+++ b/charts/wire-server-metrics/requirements.yaml
@@ -2,4 +2,5 @@
 dependencies:
   - name: prometheus-operator
     version: 6.7.2
-    repository: "@stable"
+    repository: https://charts.helm.sh/stable
+

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -39,11 +39,14 @@ brig:
       teamSettings: https://teams.example.com # change this (on unset if team settings are not used)
       teamCreatorWelcome: https://teams.example.com/login # change this
       teamMemberWelcome: https://wire.example.com/download # change this
-    optSettings:
     emailSMS:
       general:
         emailSender: email@example.com # change this
         smsSender: "insert-sms-sender-for-twilio" # change this if SMS support is desired
+    optSettings:
+      # Sync the domain with the 'host' variable in the sftd chart
+      # uncomment this section if conference calling is not used
+      setSftStaticUrl: "https://sftd.example.om:443"
     smtp:
       host: demo-smtp # change this if you want to use your own SMTP server
       port: 25        # change this
@@ -60,10 +63,10 @@ proxy:
 #  image:
 #    tag: some-tag (only override if you want a newer/different version than what is in the chart)
 #  config:
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -85,10 +88,10 @@ cargohold:
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
       s3DownloadEndpoint: https://assets.example.com
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -105,10 +108,10 @@ galley:
       conversationCodeURI: https://example.com/join/ # change this
     aws:
       region: "eu-west-1"
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 
@@ -128,10 +131,10 @@ gundeck:
       queueName: integration-gundeck-events
       sqsEndpoint: http://fake-aws-sqs:4568
       snsEndpoint: http://fake-aws-sns:4575
-#    proxy: 
+#    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"
-#      noProxyList: 
+#      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
 

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -39,6 +39,8 @@ brig:
       teamSettings: https://teams.example.com # change this (on unset if team settings are not used)
       teamCreatorWelcome: https://teams.example.com/login # change this
       teamMemberWelcome: https://wire.example.com/download # change this
+    optSettings:
+      setFederationDomain: example.com # change this
     emailSMS:
       general:
         emailSender: email@example.com # change this
@@ -104,6 +106,7 @@ galley:
       host: cassandra-ephemeral
       replicaCount: 1
     settings:
+      federationDomain: example.com # change this
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://example.com/join/ # change this
     aws:

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -17,7 +17,6 @@ elasticsearch-index:
     host: elasticsearch-external
   cassandra:
     host: cassandra-external
-
 brig:
   replicaCount: 3
 #  image:
@@ -73,6 +72,10 @@ brig:
 #      noProxyList:
 #        - "local.example.com"
 #        - "10.23.0.0/16"
+    optSettings:
+      # Sync the domain with the 'host' variable in the sftd chart
+      # uncomment this section if conference calling is not used
+      setSftStaticUrl: "https://sftd.example.om:443"
   turnStatic:
     v1:
       - "turn:turn01.example.com:80"
@@ -84,6 +87,7 @@ brig:
       - "turn:turn02.example.com:80?transport=tcp"
       - "turns:turn01.example.com:443?transport=tcp"
       - "turns:turn02.example.com:443?transport=tcp"
+
 
 proxy:
   replicaCount: 3

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -40,6 +40,8 @@ brig:
       teamSettings: https://teams.example.com # change this (or unset if team settings are not used)
       teamCreatorWelcome: https://teams.example.com/login # change this
       teamMemberWelcome: https://wire.example.com/download # change this
+    optSettings:
+      setFederationDomain: example.com # change this
     emailSMS:
       general:
         emailSender: email@example.com # change this
@@ -136,6 +138,7 @@ galley:
     settings:
       # prefix URI used when inviting users to a conversation by link
       conversationCodeURI: https://webapp.example.com/join/ # change this
+      federationDomain: example.com # change this
       # see #RefConfigOptions in `/docs/reference` (https://github.com/wireapp/wire-server/)
       featureFlags:
         sso: disabled-by-default


### PR DESCRIPTION
A new mandatory option has been introduced to
`brig` and `galley` which in the future will be used for Wire federation.  This domain name
is __NOT__ optional even if federation is not used.

Please update your `values/wire-server/values.yaml` to set `brig.optSettings.setFederationDomain`
and `galley.settings.federationDomain` (Note the slightly different option name).

**NOTE**: These changes apply to chart version **0.129.0** and later eventhough
this release was made later than that **0.129.0** chart was published. We're sorry for the
inconvenience.

