### PR TITLE
Upgrade required terraform version from 0.13.1 to 0.13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,5 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
-  test:
-    name: test
-    runs-on: ubuntu-latest
-    steps:
-      - run: cd terraform/environment && terraform init --backend-false
-    
+      - name: Check terraform init 
+        run: cd terraform/environment && terraform init --backend-false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,5 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
-      - run: which terraform
       - name: Check terraform init 
-        run: nix-shell default.nix -A env --command "cd terraform/environment && terraform init --backend=false"
+        run: $(nix-build -A env)/bin/terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
-        run: cd terraform/environment && $(nix-build -A env)/bin/terraform init --backend=false
+        run: cd terraform/environment && $(nix-build ../../default.nix -A env)/bin/terraform init --backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
-        run: cd terraform/environment && $(nix-build ../../default.nix -A env)/bin/terraform init --backend=false
+        run: | 
+          export PATH=$(nix-build -A env --no-out-link)/bin:$PATH
+          cd terraform/environment
+          terraform init --backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
-        run: cd terraform/environment && terraform init --backend-false
+        run: cd terraform/environment && terraform init --backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,9 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: cd terraform/environment && terraform init --backend-false
+    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
-      - run: terraform --version
+      - run: which terraform
       - name: Check terraform init 
-        run: cd terraform/environment && terraform init --backend=false
+        run: nix-shell default.nix -A env --command "cd terraform/environment && terraform init --backend=false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
-        run: cd terraform/environment && terraform init --backend=false
+        run: nix-shell -A env --command "cd terraform/environment && terraform init --backend=false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
-        run: $(nix-build -A env)/bin/terraform
+        run: cd terraform/environment && $(nix-build -A env)/bin/terraform init --backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
+      - run: terraform --version
       - name: Check terraform init 
-        run: nix-shell -A env --command "cd terraform/environment && terraform init --backend=false"
+        run: cd terraform/environment && terraform init --backend=false

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.1"
+  required_version = "0.13.6"
 
   required_providers {
     aws = {


### PR DESCRIPTION
The nixpkgs update https://github.com/wireapp/wire-server-deploy/pull/408 installed terraform `0.13.6` but we requires `0.13.1`
Added github action check with `terraform init --backend=false`.