### PR TITLE
[ansible,terraform] Fix SFT provision & Kubspray inventory generation

### DIFF
--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -29,18 +29,20 @@
 - hosts: localhost
   become: no
   tasks:
-    - name: Get all SRV recoreds
-      route53:
-        zone: "{{ root_domain }}"
-        type: "SRV"
-        record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
-        state: get
-      register: srv_records
-    - name: Delete all SRV records
-      route53:
-        zone: "{{ root_domain }}"
-        type: "SRV"
-        record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
-        state: "delete"
-        value: "{{ srv_records.set.value }}"
-        ttl: "{{ srv_records.set.ttl }}"
+    - when: "{{ (groups['sft_servers'] | length) > 0 }}"
+      block:
+      - name: Get all SRV recoreds
+        route53:
+          zone: "{{ root_domain }}"
+          type: "SRV"
+          record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
+          state: get
+        register: srv_records
+      - name: Delete all SRV records
+        route53:
+          zone: "{{ root_domain }}"
+          type: "SRV"
+          record: "_sft._tcp.{{ environment_name }}.{{ root_domain }}"
+          state: "delete"
+          value: "{{ srv_records.set.value }}"
+          ttl: "{{ srv_records.set.ttl }}"

--- a/terraform/environment/inventory.tf
+++ b/terraform/environment/inventory.tf
@@ -15,7 +15,7 @@ output "inventory" {
       "hosts" = { for instance in concat(local.sft_instances_blue, local.sft_instances_green): instance.hostname => {
         "ansible_host" = instance.ipaddress
         "sft_fqdn" = instance.fqdn
-        "srv_announcer_record_target": instance.fqdn
+        "srv_announcer_record_target" = instance.fqdn
         "srv_announcer_zone_domain" = var.root_domain
         "srv_announcer_aws_key_id" = module.sft[0].sft.aws_key_id
         "srv_announcer_aws_access_key" = module.sft[0].sft.aws_access_key
@@ -36,6 +36,10 @@ output "inventory" {
     "etcd" = {"hosts" = local.kubernetes_hosts}
     "minio" = {"hosts" = local.kubernetes_hosts}
     "k8s-cluster" = {
+      "children" = {
+        "kube-master" = {}
+        "kube-node" = {}
+      }
       "hosts" = {for node in local.kubernetes_nodes :
         node.hostname => {
           "ansible_host" = node.ipaddress


### PR DESCRIPTION
These two are some leftovers and should help to prevent some side-effects. The
inventory change reflects what Kubspray actually expects. And adding the condition
for flushing the SRV records prevents exactly that when using the bootstrap.yaml
playbook (like it is in the first localhost play at the top).