### PR TITLE
[tf:modules,env] Factor DNS module out of hetzner-kubernetes 

### DIFF
--- a/terraform/environment/kubernetes.dns.tf
+++ b/terraform/environment/kubernetes.dns.tf
@@ -1,0 +1,11 @@
+module "kubernetes-dns-records" {
+  for_each = toset(var.root_domain != null && length(var.sub_domains) > 0 ? [var.environment] : [])
+
+  source = "../modules/aws-dns-records"
+
+  zone_fqdn = var.root_domain
+  domain = var.environment
+  subdomains = var.sub_domains
+  ips = [ for node in local.kubernetes_nodes: node.ipaddress ]
+  create_spf_record = var.create_spf_record
+}

--- a/terraform/environment/kubernetes.dns.vars.tf
+++ b/terraform/environment/kubernetes.dns.vars.tf
@@ -1,0 +1,14 @@
+variable "root_domain" {
+  type = string
+  default = null
+}
+
+variable "sub_domains" {
+  type = list(string)
+  default = []
+}
+
+variable "create_spf_record" {
+  type = bool
+  default = false
+}

--- a/terraform/environment/kubernetes.tf
+++ b/terraform/environment/kubernetes.tf
@@ -25,7 +25,6 @@ module "hetzner_kubernetes" {
   source = "../modules/hetzner-kubernetes"
 
   environment = var.environment
-  root_domain = var.root_domain
   server_type = var.kubernetes_server_type
   ssh_keys = local.hcloud_ssh_keys
   node_count = var.kubernetes_node_count

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -1,7 +1,0 @@
-variable "environment" {
-  type = string
-}
-
-variable "root_domain" {
-  type = string
-}

--- a/terraform/environment/main.vars.tf
+++ b/terraform/environment/main.vars.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -17,14 +17,21 @@ AWS resources: route53
 module "dns_records" {
   source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-dns-records?ref=CHANGE-ME"
 
-  environment = "staging"
-
   zone_fqdn = "example.com"
+  domain = "staging"
+  sub_domains = [
+    "nginz-https",
+    "nginz-ssl",
+    "webapp",
+    "assets",
+    "account",
+    "teams"
+  ]
   ips = [ "9.9.9.10", "23.42.23.42" ]
 }
 ```
 
-If not further specified, it creates entries for the following FQDNs:
+This creates entries for the following FQDNs:
 
 * `nginz-https.staging.example.com`
 * `nginz-ssl.staging.example.com`

--- a/terraform/modules/aws-dns-records/locals.tf
+++ b/terraform/modules/aws-dns-records/locals.tf
@@ -1,6 +1,6 @@
 locals {
   name_suffix = concat(
-    var.inject_addition_subtree ? [(var.domain != null ? var.domain : var.environment)] : [],
+    var.domain != null ? [var.domain] : [],
     [var.zone_fqdn]
   )
 }

--- a/terraform/modules/aws-dns-records/variables.tf
+++ b/terraform/modules/aws-dns-records/variables.tf
@@ -1,9 +1,3 @@
-variable "environment" {
-  type        = string
-  description = "name of the environment as a scope for the created resources (default: 'dev'; example: 'prod', 'staging')"
-  default     = "dev"
-}
-
 variable "zone_fqdn" {
   type        = string
   description = "FQDN of the DNS zone root (required; example: example.com; will append: '.')"
@@ -11,27 +5,13 @@ variable "zone_fqdn" {
 
 variable "domain" {
   type        = string
-  description = "name of the sub-tree all given subdomains are append to (defaults to $environment; example: $subdomains[0].$domain.$zone_fqdn)"
+  description = "name of the sub-tree all given subdomains are append to (default: not set; example: $subdomains[0].$domain.$zone_fqdn)"
   default     = null
 }
 
 variable "subdomains" {
   type        = list(string)
-  description = "list of sub-domains that will be registered under the given root domain"
-  default = [
-    "nginz-https",
-    "nginz-ssl",
-    "webapp",
-    "assets",
-    "account",
-    "teams"
-  ]
-}
-
-variable "inject_addition_subtree" {
-  type        = bool
-  description = "flag to indicate whether an additional level of depth based on environment name is injected into the DNS tree (e.g. webapp.dev.example.com vs. webapp.example.com"
-  default     = true
+  description = "list of sub-domains that will be registered directly under the given zone or otherwise under domain if defined"
 }
 
 variable "ips" {

--- a/terraform/modules/hetzner-kubernetes/main.tf
+++ b/terraform/modules/hetzner-kubernetes/main.tf
@@ -15,13 +15,3 @@ resource "hcloud_server" "node" {
     member = "etcd${ format("%02d", count.index + 1 )}"
   }
 }
-
-module "dns_records" {
-  source = "../aws-dns-records"
-
-  environment = var.environment
-
-  zone_fqdn = var.root_domain
-  ips = [ for node in hcloud_server.node: node.ipv4_address ]
-  create_spf_record = true
-}

--- a/terraform/modules/hetzner-kubernetes/variables.tf
+++ b/terraform/modules/hetzner-kubernetes/variables.tf
@@ -21,7 +21,3 @@ variable "location" {
 variable "node_count"  {
   type = number
 }
-
-variable "root_domain" {
-  type = string
-}


### PR DESCRIPTION
NOTE: when the previous version of hetzner-kubernetes has been used before, part of the
TF state must be moved/migrated with `terraform state mv`

Additionally, environements already using this module, must set
```
sub_domains = [
  "nginz-https",
  "nginz-ssl",
  "webapp",
  "assets",
  "account",
  "teams"
]
```

dns module:
* removed var 'inject_addition_subtree' and instead indicating adding a sub-tree
  by whether 'domain' is defined or not
* default to an empty 'subdomains' instead of a pre-defined & opinionated list

instantiate DNS module:
* subdomains must explicitly be defined in environment configuration

*Co-Authored: @lucendio*