### PR TITLE
Ansible fixes

### DIFF
--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -10,7 +10,6 @@
   tasks:
     - name: Annotate nodes
       command: "kubectl annotate node --overwrite {{ inventory_hostname }} {{ item.key }}={{ item.value }}"
-      when: node_annotations is defined
-      with_dict: node_annotations
+      with_dict: node_annotations | default({})
 
 - import_playbook: kubernetes_logging.yml

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -10,6 +10,6 @@
   tasks:
     - name: Annotate nodes
       command: "kubectl annotate node --overwrite {{ inventory_hostname }} {{ item.key }}={{ item.value }}"
-      with_dict: node_annotations | default({})
+      with_dict: "{{ node_annotations | default({}) }}"
 
 - import_playbook: kubernetes_logging.yml

--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -1,6 +1,7 @@
 # This role requires access to s3 buckets and has a few variables that need to
 # be set. When run with any variables missing, it will complain about those
 # variables.
+# To replace hosts: localhost as suggested in http://willthames.github.io/2018/07/01/connection-local-vs-delegate_to-localhost.html
 - hosts: fakehost
   connection: local
   vars:

--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -1,8 +1,11 @@
 # This role requires access to s3 buckets and has a few variables that need to
 # be set. When run with any variables missing, it will complain about those
 # variables.
-- hosts: localhost
-  become: no
+- hosts: fakehost
+  connection: local
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  gather_facts: no
   roles:
     - role: sft-monitoring-certs
       when: "{{ (groups['sft_servers'] | length) > 0 }}"
@@ -26,8 +29,11 @@
         group: root
         state: link
 
-- hosts: localhost
-  become: no
+- hosts: fakehost
+  connection: local
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  gather_facts: no
   tasks:
     - name: Get all SRV recoreds
       route53:


### PR DESCRIPTION
The `with_dict` fix is to prevent this from happening:
```
TASK [Annotate nodes] ************************************************************************************************************************
task path: /Users/jmatsushita/dev/wire-server-deploy/ansible/kubernetes.yml:11
fatal: [ci-dev-kubenode01]: FAILED! => {"msg": "with_dict expects a dict"}
fatal: [ci-dev-kubenode02]: FAILED! => {"msg": "with_dict expects a dict"}
fatal: [ci-dev-kubenode03]: FAILED! => {"msg": "with_dict expects a dict"}
```

The `host: localhost` replacement is to prevent this from happening:
```
TASK [Get all SRV recoreds] ******************************************************************************************************************
task path: /Users/jmatsushita/dev/wire-server-deploy/ansible/provision-sft.yml:32
fatal: [localhost]: FAILED! => {"changed": false, "msg": "boto required for this module"}
```