### PR TITLE
kubespray: 2.14 -> 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   should be installed with helm 3.
 
 * Our kubespray reference implementation has been bumped to kuberspray 2.15.0
-  and kubernetes 1.97.7. This allows us to use Kubespray's support for offline deployments
+  and kubernetes 1.19.7. This allows us to use Kubespray's support for offline deployments
   and new Kubernetes API features.
 
   If you were using our reference playbooks for setting up kubernetes, there is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   wire-server instead and is decoupled from the underlying platform. Charts in wire-server
   should be installed with helm 3.
 
-* Our kubespray reference implementation has been bumped to kuberspray 2.14.2
-  and kubernetes 1.18.2. This allows us to use Kubespray's support for offline deployments
+* Our kubespray reference implementation has been bumped to kuberspray 2.15.0
+  and kubernetes 1.97.7. This allows us to use Kubespray's support for offline deployments
   and new Kubernetes API features.
 
   If you were using our reference playbooks for setting up kubernetes, there is

--- a/nix/pkgs/kubectl.nix
+++ b/nix/pkgs/kubectl.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "kubectl";
-  version = "1.18.10";
+  version = "1.19.7";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/linux/amd64/kubectl";
-      sha256 = "0mhlpailnfq5c6i9ka2ws5z8grylrq5va4qcb7g6icbandf48p5j";
+      sha256 = "15vjydl91h0igvps2zcxj9bjyksb88ckavdwxmmmnpjpwaxv6vnl";
     };
     x86_64-darwin = fetchurl {
       url = "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/darwin/amd64/kubectl";
-      sha256 = "0nz6f44qh16di6249qwczvr1mpmhvzbi0kd1himxlhsp34qfr993";
+      sha256 = "1gpn6l8l5zznkrvydjv5km906adniid4wpsqy3qpdzlmgpscx1ir";
     };
   }."${stdenv.targetPlatform.system}";
 


### PR DESCRIPTION
This is 2.15 with https://github.com/kubernetes-sigs/kubespray/pull/7247
cherry-picked on top; as we need it for offline deploy.

It will allow us to point the docker install playbook to an alternative
package repository.

Though 2.14 we never had in a release, I will still provide some upgrade
instructions:

To upgrade an existing cluster follow the instructions here:
https://kubespray.io/#/docs/upgrades?id=graceful-upgrade

```
$ cd ansible
$ ansible-playbook ./roles-external/kubespray/upgrade-cluster.yml -i ./your-inventory
```

This should guide you through the upgrade process step by step.