### PR TITLE
[RFC] Introduce Terraform interface modules to reflect atomic pieces of infrastructure

### DIFF
--- a/terraform/environment/inventory.tf
+++ b/terraform/environment/inventory.tf
@@ -1,3 +1,7 @@
+# TODO: allow outputting multiple inventories (for each module instance returning an inventory)
+#       and/or merge them ('all', 'hosts', 'groups'). This might need to be solved on the 'make'
+#       level.
+
 # Generates an inventory file to be used by ansible. Ideally, we would generate
 # this outside terraform using outputs, but it is not possible to use 'terraform
 # output' when the init directory is different from the root code directory.

--- a/terraform/environment/kubernetes-aws.tf
+++ b/terraform/environment/kubernetes-aws.tf
@@ -1,0 +1,16 @@
+variable "kubernetes_aws" {
+  type = list(any)
+  default = []
+}
+
+
+module "kubernetes_aws" {
+  for_each = { for k,v in var.kubernetes_aws : v.name => v }
+  source = "./../interfaces/kubernetes-aws"
+
+  name = each.value.name
+
+  node_pools = each.value.node_pools
+
+  is_managed = try(each.value.is_managed, false)
+}

--- a/terraform/environment/kubernetes-hetzner.tf
+++ b/terraform/environment/kubernetes-hetzner.tf
@@ -1,0 +1,20 @@
+variable "kubernetes_hetzner" {
+  type = list(any)
+  default = []
+}
+
+
+module "kubernetes_hetzner" {
+  for_each = { for k,v in var.kubernetes_hetzner : v.name => v }
+  source = "./../interfaces/kubernetes-hetzner"
+
+  name = each.value.name
+
+  control_plane = each.value.control_plane
+  node_pools = each.value.node_pools
+
+  with_load_balancer = try(each.value.with_load_balancer, false)
+  load_balancer_ports = try(each.value.load_balancer_ports, [])
+  root_domain = try(each.value.root_domain, null)
+  sub_domains = try(each.value.sub_domains, [])
+}

--- a/terraform/infra/Makefile
+++ b/terraform/infra/Makefile
@@ -1,0 +1,4 @@
+# This file would probably look very similar to ./../environment/Makefile
+# but I wont bother implementing it, since the Makefiles will be consolidated
+# into the repo's top-level anyway very soon, combining Terraform, Ansible &
+# Helmfile invocation

--- a/terraform/infra/README.md
+++ b/terraform/infra/README.md
@@ -1,0 +1,3 @@
+While `./../environment` should only act on TF variables related to creating a Wire platform
+instance, this folder here follows the same *less copy&pasta approach* (`.tfvars` in a folder in *cailleach*)
+but 'listens' to other variables.

--- a/terraform/infra/bucket-aws.tf
+++ b/terraform/infra/bucket-aws.tf
@@ -1,0 +1,16 @@
+# NOTE: this is just an example, including ./../interfaces/bucket-aws
+
+variable "bucket_aws" {
+  type = list(any)
+  default = []
+}
+
+
+module "bucket_aws_instances" {
+  for_each = { for k,v in var.bucket_aws : v.name => v }
+  source = "./../interfaces/bucket-aws"
+
+  name = each.value.name
+
+  is_public = try(each.value.is_public, false)
+}

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "0.13.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+    hcloud = {
+      source  = "terraform-providers/hcloud"
+      version = "~> 1.19"
+    }
+  }
+}

--- a/terraform/infra/provider.aws.tf
+++ b/terraform/infra/provider.aws.tf
@@ -1,0 +1,7 @@
+variable "aws_region" {
+  default = "eu-central-1"
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/infra/provider.hcloud.tf
+++ b/terraform/infra/provider.hcloud.tf
@@ -1,0 +1,3 @@
+provider "hcloud" {
+  # NOTE: You must have a HCLOUD_TOKEN environment variable set!
+}

--- a/terraform/infra/sft-deployment-hetzner.tf
+++ b/terraform/infra/sft-deployment-hetzner.tf
@@ -1,0 +1,6 @@
+variable "sft_deployment_hetzner" {
+  type = list(any)
+  default = []
+}
+
+# TODO: move ./../environment/sft* over here

--- a/terraform/interfaces/README.md
+++ b/terraform/interfaces/README.md
@@ -1,0 +1,12 @@
+Infrastructure interfaces
+=========================
+
+## Terminology
+
+__interface module:__ while technically a TF module, its purpose is to be a thin wrapper module representing
+    an atomic piece of infrastructure that should be reused and instantiated by defining an *interface variable*
+    and add an item to the list.
+
+__interface variable:__ should always be of type `list` containing objects with the attribute `name` at least.
+
+Module (name & folder) and variable show share the same name. 

--- a/terraform/interfaces/bucket-aws/README.md
+++ b/terraform/interfaces/bucket-aws/README.md
@@ -1,0 +1,1 @@
+Only meant as an example for an *interface module*.

--- a/terraform/interfaces/bucket-aws/aws-s3.tf
+++ b/terraform/interfaces/bucket-aws/aws-s3.tf
@@ -1,0 +1,6 @@
+module "bucket" {
+  source = "./../../modules/aws-s3"
+
+  bucketPrefix = var.name
+  accessControl = var.is_public ? "public-read" : "private"
+}

--- a/terraform/interfaces/bucket-aws/outputs.tf
+++ b/terraform/interfaces/bucket-aws/outputs.tf
@@ -1,0 +1,3 @@
+output "full_name" {
+  value = module.bucket.id
+}

--- a/terraform/interfaces/bucket-aws/variables.tf
+++ b/terraform/interfaces/bucket-aws/variables.tf
@@ -1,0 +1,8 @@
+variable "name" {
+  type = string
+}
+
+variable "is_public" {
+  type = bool
+  default = false
+}

--- a/terraform/interfaces/kubernetes-aws/modules.tf
+++ b/terraform/interfaces/kubernetes-aws/modules.tf
@@ -1,0 +1,5 @@
+# module "kubernetes" {
+#   count = var.is_managed ? 1 : 0
+#   source = "./../../modules/aws-eks"
+#   ...
+# }

--- a/terraform/interfaces/kubernetes-aws/outputs.inventory.tf
+++ b/terraform/interfaces/kubernetes-aws/outputs.inventory.tf
@@ -1,0 +1,5 @@
+output "inventory" {
+  value = {
+    # TODO
+  }
+}

--- a/terraform/interfaces/kubernetes-aws/variables.tf
+++ b/terraform/interfaces/kubernetes-aws/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type = string
+}
+
+variable "node_pools" {
+  type = list(object({
+    name = string
+    count = number
+    machine_type = string
+  }))
+}
+
+variable "is_managed" {
+  type = bool
+  default = false
+}

--- a/terraform/interfaces/kubernetes-hetzner/modules.dns.tf
+++ b/terraform/interfaces/kubernetes-hetzner/modules.dns.tf
@@ -1,0 +1,4 @@
+# module "dns" {
+#   source = "./../../modules/aws-dns-records"
+#   ...
+# }

--- a/terraform/interfaces/kubernetes-hetzner/modules.kubernetes.tf
+++ b/terraform/interfaces/kubernetes-hetzner/modules.kubernetes.tf
@@ -1,0 +1,4 @@
+# module "kubernetes" {
+#   source = "./../../modules/hetzner-kubernetes"
+#   ...
+# }

--- a/terraform/interfaces/kubernetes-hetzner/outputs.inventory.tf
+++ b/terraform/interfaces/kubernetes-hetzner/outputs.inventory.tf
@@ -1,0 +1,5 @@
+output "inventory" {
+  value = {
+    # TODO: adapt ./../../environment/kubernetes.inventory.tf
+  }
+}

--- a/terraform/interfaces/kubernetes-hetzner/resources.network.tf
+++ b/terraform/interfaces/kubernetes-hetzner/resources.network.tf
@@ -1,0 +1,23 @@
+# TODO: feed into the kubernetes module
+
+resource "hcloud_network" "nw" {
+  count = var.network_id != null ? 1 : 0
+
+  name = "k8s-${ var.name }"
+
+  ip_range = "192.168.0.0/16"
+}
+
+
+resource "hcloud_network_subnet" "sn" {
+  count = var.network_id != null && var.subnet_id != null ? 1 : 0
+
+  network_id = hcloud_network.nw.id
+
+  ip_range   = "192.168.1.0/24"
+
+  # NOTE: No other sensible values available at this time
+  # DOCS: https://docs.hetzner.cloud/#subnets
+  type = "cloud"
+  network_zone = "eu-central"
+}

--- a/terraform/interfaces/kubernetes-hetzner/variables.tf
+++ b/terraform/interfaces/kubernetes-hetzner/variables.tf
@@ -1,0 +1,54 @@
+variable "name" {
+  type = string
+}
+
+variable "control_plane" {
+  type = object({
+    count = number
+    is_worker = bool
+    machine_type = string
+  })
+}
+
+variable "node_pools" {
+  type = list(object({
+    name = string
+    count = number
+    machine_type = string
+  }))
+}
+
+variable "with_load_balancer" {
+  type = bool
+  default = false
+}
+
+variable "load_balancer_ports" {
+  type = list(object({
+    name = string
+    protocol = string
+    listen = number
+    destination = number
+  }))
+  default = []
+}
+
+variable "root_domain" {
+  type = string
+  default = null
+}
+
+variable "sub_domains" {
+  type = list(string)
+  default = []
+}
+
+variable "network_id" {
+  type = string
+  default = null
+}
+
+variable "subnet_id" {
+  type = string
+  default = null
+}

--- a/terraform/modules/aws-s3/README.md
+++ b/terraform/modules/aws-s3/README.md
@@ -1,0 +1,2 @@
+Just an example module. Does not manage any real remote resource. Should be removed
+before merging this branch.

--- a/terraform/modules/aws-s3/bucket.resources.tf
+++ b/terraform/modules/aws-s3/bucket.resources.tf
@@ -1,0 +1,14 @@
+resource "random_string" "suffix" {
+  count = var.bucketPrefix != null ? 1 : 4
+
+  length = 6
+
+  lower   = true
+  upper   = false
+  number  = true
+  special = false
+
+  keepers = {
+    bucketPrefix = var.bucketPrefix
+  }
+}

--- a/terraform/modules/aws-s3/bucket.variables.tf
+++ b/terraform/modules/aws-s3/bucket.variables.tf
@@ -1,0 +1,9 @@
+variable "bucketPrefix" {
+  type = string
+  default = null
+}
+
+variable "accessControl" {
+  type = string
+  default = "private"
+}

--- a/terraform/modules/aws-s3/buket.outputs.tf
+++ b/terraform/modules/aws-s3/buket.outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = random_string.suffix[0].keepers.bucketPrefix
+}

--- a/terraform/modules/aws-s3/main.tf
+++ b/terraform/modules/aws-s3/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
* introduce another folder to manage infrastructure other then a Wire K8s instance
* add example code to showcase thin wrapper modules (aka interface module) to define atomic/reusable pieces of infrastructure

### TODOs from https://github.com/wireapp/wire-server-deploy/pull/418

* [ ] validate etcd (or only give specific choices) according to the [Raft toleration behaviour](https://etcd.io/docs/v3.3.13/faq/#what-is-failure-tolerance)
* [ ] change interface design according to the [suggestion](https://github.com/wireapp/wire-server-deploy/pull/418#discussion_r577643963)
* [ ] decide whether to keep volume creation in there
* [ ] factor out private network creation