### PR TITLE
Move to wire-server-deploy cachix cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: cachix/install-nix-action@v12
       - uses: cachix/cachix-action@v8
         with:
-          name: wire-server
+          name: wire-server-deploy
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix-build -A env
       - name: Check terraform init 
         run: | 


### PR DESCRIPTION
The old cache is gone (was on my private account. now using Wire's account)