### PR TITLE
Set `access_ip` for machines as well

### DIFF
--- a/terraform/environment/kubernetes.inventory.tf
+++ b/terraform/environment/kubernetes.inventory.tf
@@ -17,6 +17,7 @@ locals {
           {
             ansible_host = m.public_ipv4
             ip = m.private_ipv4
+            access_ip = m.private_ipv4
           },
           contains(keys(m), "etcd_member_name" ) ? { etcd_member_name = m.etcd_member_name } : {}
         )


### PR DESCRIPTION
Otherwise etcd will try to form a cluster over the public network which e.g. won't work in offline and also `etcd` benefits from the lower latencies.