### PR TITLE
Add srv to dns module

### DIFF
--- a/terraform/environment/Makefile
+++ b/terraform/environment/Makefile
@@ -29,7 +29,7 @@ create-inventory: check-env
 		terraform output -json inventory > ${ENV_DIR}/gen/terraform-inventory.yml
 
 .PHONY: apply plan console destroy
-apply plan console destroy:
+apply plan console destroy: check-env
 	source ${ENV_DIR}/hcloud-token.dec && \
 		terraform $@ -var-file=${ENV_DIR}/terraform.tfvars
 

--- a/terraform/environment/kubernetes.dns.tf
+++ b/terraform/environment/kubernetes.dns.tf
@@ -3,10 +3,10 @@ module "kubernetes-dns-records" {
 
   source = "../modules/aws-dns-records"
 
-  zone_fqdn = var.root_domain
-  domain = var.environment
+  zone_fqdn  = var.root_domain
+  domain     = var.environment
   subdomains = var.sub_domains
-  ips = module.hetzner_k8s_cluster[var.environment].ips
+  ips        = module.hetzner_k8s_cluster[var.environment].ips
   # NOTE: this list could have been generated similar to ./kubernetes.inventory.tf, but
   #       Terraform thinks differently. While building up the dependency tree, it appears
   #       that it is not able to see indirect dependencies, e.g. local.cluster_machines.  #
@@ -17,4 +17,6 @@ module "kubernetes-dns-records" {
   #
   #       So, in order to work around this, a second output for public node IPs is being introduced.
   spf_record_ips = module.hetzner_k8s_cluster[var.environment].node_ips
+
+  srvs = var.srvs
 }

--- a/terraform/environment/kubernetes.dns.vars.tf
+++ b/terraform/environment/kubernetes.dns.vars.tf
@@ -1,14 +1,19 @@
 variable "root_domain" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "sub_domains" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "create_spf_record" {
-  type = bool
+  type    = bool
   default = false
+}
+
+variable "srvs" {
+  type    = map(list(string))
+  default = {}
 }

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -50,7 +50,7 @@ This creates entries for the following FQDNs:
 
 It also creates a TXT SPF record for your mail server on `staging.example.com` with a value `"v=spf1 ip4:9.9.9.10 ip4:23.42.23.42 -all"`
 
-As well as a SRV record `_wire-server._tcp.staging.example.com` pointing to `0 10 443 nginz-https.staging.example.com`
+As well as an SRV record `_wire-server._tcp.staging.example.com` pointing to `0 10 443 nginz-https.staging.example.com`
 
 These sub-domains represent the primary set of FQDNs used in a
 [`wire-server` installation](https://docs.wire.com/how-to/install/helm-prod.html#how-to-set-up-dns-records),

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -35,10 +35,7 @@ module "dns_records" {
   spf_record_ips = [ "9.9.9.10", "23.42.23.42" ]
 
   # Optional
-  srvs = {
-    prefix = "_wire-server._tcp"
-    target_prefixes = [ "0 10 443 nginz-https" ]
-  }
+  srvs = { "_wire-server._tcp" = [ "0 10 443 nginz-https" ] }
 }
 ```
 
@@ -52,6 +49,8 @@ This creates entries for the following FQDNs:
 * `teams.staging.example.com`
 
 It also creates a TXT SPF record for your mail server on `staging.example.com` with a value `"v=spf1 ip4:9.9.9.10 ip4:23.42.23.42 -all"`
+
+As well as a SRV record `_wire-server._tcp.staging.example.com` pointing to `0 10 443 nginz-https.staging.example.com`
 
 These sub-domains represent the primary set of FQDNs used in a
 [`wire-server` installation](https://docs.wire.com/how-to/install/helm-prod.html#how-to-set-up-dns-records),

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -34,6 +34,11 @@ module "dns_records" {
   # Optional
   spf_record_ips = [ "9.9.9.10", "23.42.23.42" ]
 
+  # Optional
+  srvs = {
+    prefix = "_wire-server._tcp"
+    target_prefixes = [ "0 10 443 nginz-https" ]
+  }
 }
 ```
 

--- a/terraform/modules/aws-dns-records/README.md
+++ b/terraform/modules/aws-dns-records/README.md
@@ -13,6 +13,8 @@ AWS resources: route53
 
 #### How to use the module
 
+Assuming you already have a root zone with fqdn `example.com` in route53 setup elsewhere, example usage:
+
 ```hcl
 module "dns_records" {
   source = "github.com/wireapp/wire-server-deploy.git//terraform/modules/aws-dns-records?ref=CHANGE-ME"
@@ -28,6 +30,10 @@ module "dns_records" {
     "teams"
   ]
   ips = [ "9.9.9.10", "23.42.23.42" ]
+
+  # Optional
+  spf_record_ips = [ "9.9.9.10", "23.42.23.42" ]
+
 }
 ```
 
@@ -39,6 +45,8 @@ This creates entries for the following FQDNs:
 * `assets.staging.example.com`
 * `account.staging.example.com`
 * `teams.staging.example.com`
+
+It also creates a TXT SPF record for your mail server on `staging.example.com` with a value `"v=spf1 ip4:9.9.9.10 ip4:23.42.23.42 -all"`
 
 These sub-domains represent the primary set of FQDNs used in a
 [`wire-server` installation](https://docs.wire.com/how-to/install/helm-prod.html#how-to-set-up-dns-records),

--- a/terraform/modules/aws-dns-records/resources.route53.tf
+++ b/terraform/modules/aws-dns-records/resources.route53.tf
@@ -28,20 +28,20 @@ resource "aws_route53_record" "spf" {
   ttl     = "60"
   records = [
     join(" ", concat(
-      [ "v=spf1" ],
-      [ for ip in var.spf_record_ips : "ip4:${ ip }" ],
-      [ "-all" ]
+      ["v=spf1"],
+      [for ip in var.spf_record_ips : "ip4:${ip}"],
+      ["-all"]
     ))
   ]
 }
 
 resource "aws_route53_record" "srv-server" {
-  count = length(var.srvs.target_prefixes) > 0 ? 1 : 0
+  for_each = var.srvs
 
   zone_id = data.aws_route53_zone.rz.zone_id
-  name    = join(".", concat([var.srvs.prefix], local.name_suffix))
+  name    = join(".", concat([each.key], local.name_suffix))
   type    = "SRV"
   ttl     = "60"
 
-  records = [for t in var.srvs.target_prefixes : join(".", concat([t], local.name_suffix))]
+  records = [for t in each.value : join(".", concat([t], local.name_suffix))]
 }

--- a/terraform/modules/aws-dns-records/resources.route53.tf
+++ b/terraform/modules/aws-dns-records/resources.route53.tf
@@ -34,3 +34,14 @@ resource "aws_route53_record" "spf" {
     ))
   ]
 }
+
+resource "aws_route53_record" "srv-server" {
+  count = length(var.srvs.target_prefixes) > 0 ? 1 : 0
+
+  zone_id = data.aws_route53_zone.rz.zone_id
+  name    = join(".", concat([var.srvs.prefix], local.name_suffix))
+  type    = "SRV"
+  ttl     = "60"
+
+  records = [for t in var.srvs.target_prefixes : join(".", concat([t], local.name_suffix))]
+}

--- a/terraform/modules/aws-dns-records/variables.tf
+++ b/terraform/modules/aws-dns-records/variables.tf
@@ -33,7 +33,19 @@ variable "ttl" {
 }
 
 variable "spf_record_ips" {
-  type    = list(string)
+  type        = list(string)
   description = "list of IPs converted into a list of 'ip4' mechanisms"
-  default = []
+  default     = []
+}
+
+variable "srvs" {
+  type = object({
+    prefix          = string,
+    target_prefixes = list(string)
+  })
+  description = "..."
+  default = {
+    prefix          = "nginz-https",
+    target_prefixes = []
+  }
 }

--- a/terraform/modules/aws-dns-records/variables.tf
+++ b/terraform/modules/aws-dns-records/variables.tf
@@ -39,13 +39,7 @@ variable "spf_record_ips" {
 }
 
 variable "srvs" {
-  type = object({
-    prefix          = string,
-    target_prefixes = list(string)
-  })
-  description = "..."
-  default = {
-    prefix          = "nginz-https",
-    target_prefixes = []
-  }
+  type        = map(list(string))
+  description = "map of SRV records and their list of targets. All strings (record and targets) get an automatic suffix of '.domain.zone_fqdn'. See module README for an example."
+  default     = {}
 }


### PR DESCRIPTION
For federation, we will in a first phase (subject to change later) use SRV records for server discovery between backends. For that, we need SRV record support in this module and the kubernetes environment.