### PR TITLE
update bin/secrets.sh to aid in creating fresh environments with fres…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ values-init-done
 # Nix-created result symlinks
 result
 result-*
+
+# for bin/secrets.sh
+secrets_cache/

--- a/bin/secrets.sh
+++ b/bin/secrets.sh
@@ -3,7 +3,12 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOPLEVEL_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
 
-OUTPUT_DIR="$TOPLEVEL_DIR/secrets_cache"
+# Generates fresh zauth, TURN/restund, nginx/basic-auth and minio secrets as one-secret-per file. This can be useful in ansible-based deployments.
+# Then templates those secrets together in a secrets.yaml file for use in helm deployments.
+# USAGE:
+# ./bin/secrets.sh [ path-to-new-directory-for-secrets-output | default ./secrets_cache ]
+
+OUTPUT_DIR="${1:-"$TOPLEVEL_DIR/secrets_cache"}"
 
 mkdir -p "$OUTPUT_DIR"
 

--- a/bin/secrets.sh
+++ b/bin/secrets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOPLEVEL_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
 
@@ -61,7 +63,8 @@ else
 fi
 
 echo ""
-echo "You could use the generated"
+echo "1. You can use the generated $OUTPUT_DIR/secrets_ansible.yaml file as part of your ansible group_vars/. Copy this to your inventory."
+echo "2. You could use the generated"
 echo "   $OUTPUT_DIR/secrets.yaml"
 echo "as a basis for your helm overrides (adjust as needed)"
 
@@ -121,3 +124,9 @@ team-settings:
         # TODO: you need an access key from a Wire employee to enable team settings.
         # configjson [ewog...end] corresponds to <TODO quay.io robot account name>
 " > "$OUTPUT_DIR/secrets.yaml"
+
+echo "
+restund_zrest_secret: \"$(cat "$zrest")\"
+minio_access_key: \"$(cat "$miniopub")\"
+minio_secret_key: \"$(cat "$miniopriv")\"
+" > "$OUTPUT_DIR/secrets_ansible.yaml"


### PR DESCRIPTION
…h secrets

Motivation: as I was creating new environments, I needed to create fresh secrets for them, and add them to a secrets.yaml file. This is currently a tedious process involving copy-pasting the right bits of string to the rightly-indented json.

If this PR is accepted, FUTUREWORK could be to A) add the existence of this script to docs.wire.com and B) we could make it even easier by providing a docker image containing zauth, openssl, and htpasswd.