### PR TITLE
Concourse deploy tooling

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -19,6 +19,23 @@ bootstrap: check-env
 		--private-key ${ENV_DIR}/operator-ssh.dec \
 		-vv
 
+.PHONY: play-%
+play-%: check-env
+	ansible-playbook ${ANSIBLE_DIR}/$(*).yml \
+		-i ${ENV_DIR}/gen/terraform-inventory.yml \
+		-i ${ENV_DIR}/inventory \
+		--private-key ${ENV_DIR}/operator-ssh.dec \
+		-vv
+
+.PHONY: upgrade-cluster
+upgrade-cluster: check-env
+	ansible-playbook ${ANSIBLE_DIR}/roles-external/kubespray/upgrade-cluster.yml \
+		-i ${ENV_DIR}/gen/terraform-inventory.yml \
+		-i ${ENV_DIR}/inventory \
+		--private-key ${ENV_DIR}/operator-ssh.dec \
+		-vv
+
+
 # FUTUREWORK: https://github.com/zinfra/backend-issues/issues/1763
 .PHONY: kube-minio-static-files
 kube-minio-static-files: check-env

--- a/ansible/helm_etcd.yml
+++ b/ansible/helm_etcd.yml
@@ -1,0 +1,31 @@
+- name: Fetch etcd certs
+  gather_facts: true
+  hosts: etcd
+  tasks:
+    - slurp:
+        src: /etc/ssl/etcd/ssl/ca.pem
+      register: etcd_ca
+    - slurp:
+        src: /etc/ssl/etcd/ssl/node-{{ inventory_hostname }}.pem
+      register: etcd_client
+    - slurp:
+        src: /etc/ssl/etcd/ssl/node-{{ inventory_hostname }}-key.pem
+      register: etcd_client_key
+    - set_fact:
+        etcd_ca_content: "{{ etcd_ca.content }}"
+        etcd_client_content: "{{ etcd_client.content }}"
+        etcd_client_key_content: "{{ etcd_client_key.content }}"
+
+- hosts: localhost
+  become: false
+  tasks:
+    - name: Provide etcd certificates for helm
+      include_tasks: tasks/helm_etcd.yml
+      vars:
+        # FIXME only need data fron the first etcd node
+        etcd_ca: "{{ hostvars['cp-01'].etcd_ca_content }}"
+        etcd_client: "{{ hostvars['cp-01'].etcd_client_content }}"
+        etcd_client_key: "{{ hostvars['cp-01'].etcd_client_key_content }}"
+        # etcd_client_key: "{{ groups['etcd'] | map('extract', hostvars, 'etcd_client_key_content') | list | join('') }}"
+        server_type: etcd
+        network_interface: "{{ etcd_network_interface | default('') }}"

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -38,3 +38,4 @@
       with_dict: "{{ node_annotations | default({}) }}"
 
 - import_playbook: kubernetes_logging.yml
+- import_playbook: helm_etcd.yml

--- a/ansible/tasks/helm_etcd.yml
+++ b/ansible/tasks/helm_etcd.yml
@@ -1,0 +1,18 @@
+---
+- name: create etcd certs directory
+  file:
+    state: directory
+    path: "{{ lookup('env', 'ENV_DIR') }}/gen/helm_vars/etcd"
+
+- name: write etcd host IPs for helm
+  template:
+    src: templates/etcd_ips.yaml.j2
+    dest: "{{ lookup('env', 'ENV_DIR') }}/gen/helm_vars/etcd/ips.yaml"
+
+- name: write etcd certs for helm
+  template:
+    src: templates/ectd_certs.yaml.j2
+    dest: "{{ lookup('env', 'ENV_DIR') }}/gen/helm_vars/etcd/certs.yaml"
+
+- name: encrypt etcd certs with helm secret
+  shell: "helm secrets enc {{ lookup('env', 'ENV_DIR') }}/gen/helm_vars/etcd/certs.yaml"

--- a/ansible/templates/ectd_certs.yaml.j2
+++ b/ansible/templates/ectd_certs.yaml.j2
@@ -1,0 +1,7 @@
+secrets:
+  etcd_ca: | 
+    {{ etcd_ca | indent(width=4) }}
+  etcd_client: | 
+    {{ etcd_client | indent(width=4) }}
+  etcd_client_key: |
+    {{ etcd_client_key | indent(width=4) }}

--- a/ansible/templates/etcd_ips.yaml.j2
+++ b/ansible/templates/etcd_ips.yaml.j2
@@ -1,0 +1,4 @@
+IPs:
+{% for host in groups[server_type] %}
+  - {{ hostvars[host]["ip"] }}
+{% endfor %}

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -19,18 +19,93 @@ endif
 
 
 
-################################### HELM ###################################
+################################### HELMFILE ###################################
 
 .PHONY: deploy
 deploy: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
 	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
 	helmfile \
 		--file $(ENV_DIR)/helmfile.yaml \
 		sync \
 			--concurrency 1
 
+.PHONY: sync apply destroy
+sync apply destroy: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		$@ \
+			--concurrency 1
 
+.PHONY: lint-%
+lint-%: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		--selector name=$(*) \
+		lint \
+			--concurrency 1
 
+.PHONY: apply-%
+apply-%: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		--selector name=$(*) \
+		apply \
+			--concurrency 1
+
+.PHONY: destroy-%
+destroy-%: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		--selector name=$(*) \
+		destroy \
+			--concurrency 1
+
+.PHONY: template-%
+template-%: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		--selector name=$(*) \
+		--log-level debug \
+		template \
+			--concurrency 1
+
+.PHONY: write-values-%
+write-values-%: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		--selector name=$(*) \
+		--log-level debug \
+		write-values \
+			--concurrency 1
+
+.PHONY: build
+build: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		$@ --embed-values
+
+.PHONY: list status write-values template
+list status write-values template: check-helm-inputs
+	source ${ENV_DIR}/hcloud-token.dec && \
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		$@
 ############################### CREDENTIALS ################################
 
 .PHONY: decrypt

--- a/terraform/environment/Makefile
+++ b/terraform/environment/Makefile
@@ -28,10 +28,26 @@ create-inventory: check-env
 	mkdir -p ${ENV_DIR}/gen && \
 		terraform output -json inventory > ${ENV_DIR}/gen/terraform-inventory.yml
 
-.PHONY: apply plan console destroy
-apply plan console destroy: check-env
+.PHONY: view-inventory
+view-inventory: check-env
+	@mkdir -p ${ENV_DIR}/gen && \
+		terraform output -json inventory
+
+.PHONY: apply plan console refresh
+apply plan console refresh:
 	source ${ENV_DIR}/hcloud-token.dec && \
 		terraform $@ -var-file=${ENV_DIR}/terraform.tfvars
+
+.PHONY: state-list
+state-list:
+	source ${ENV_DIR}/hcloud-token.dec && \
+		terraform state list 
+
+.PHONY: destroy
+destroy:
+	rm -rf ${ENV_DIR}/gen && \
+		source ${ENV_DIR}/hcloud-token.dec && \
+			terraform $@ -var-file=${ENV_DIR}/terraform.tfvars
 
 .PHONY: check-env
 check-env:


### PR DESCRIPTION
The main focus of this PR is to pass etcd information since `kubespray` installs it outside of kubernetes, so that the prometheus operator can access the etcd certificates and ip addresses. https://github.com/zinfra/cailleach/pull/521/files#diff-51b29e192d0e2c19444e320157af78ca1adeda1fcda531a30846508f11449973R37-R40

Here are a few thigns I found useful while setting up the concourse kubernetes cluster:
 - ensure the gen folder is destroyed on `make -C terraform/environment destroy EMV=ci-dev` 
 - targeted playbook for ansible with `make -C ansible play-helm_etcd ENV=ci-dev` for example.
 - targeted helmfile apply with `make -C helm apply-concourse-ci ENV=ci-dev`
 
 