### PR TITLE
[ansible] Re-introduce interpreter path setting globally

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -10,5 +10,8 @@ gathering               = smart
 
 host_key_checking       = no
 
+interpreter_python      = /usr/bin/python3
+
+
 [privilege_escalation]
 become                  = yes


### PR DESCRIPTION
We are now use Ansible v2.8 (#404) but also moved the variable out of the generated
inventory (#418). This change re-introduces the setting on a global level. Environments
that rely on an older version of Ansible as well running on older systems still have to set
in the respective inventory.

[related Ansible docs](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#interpreter-python)