### PR TITLE
[ansible] Allow overriding Kubespray version form within ENV_DIR

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -3,3 +3,4 @@ artifacts
 secrets
 *.retry
 output
+roles-override

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -11,8 +11,20 @@ provision-sft: check-env
 		--private-key ${ENV_DIR}/operator-ssh.dec \
 		-vv
 
+.PHONY: roles-override
+.SILENT: roles-override
+roles-override:
+	[ -e $(ENV_DIR)/kubespray.ref ] \
+	&& ( \
+		rm -rf ./roles-override; \
+		git clone https://github.com/kubernetes-sigs/kubespray ./roles-override/kubespray; \
+		cd ./roles-override/kubespray; \
+		git config advice.detachedHead false; \
+		git checkout "$$(cat $(ENV_DIR)/kubespray.ref)"; \
+	)
+
 .PHONY: bootstrap
-bootstrap: check-env
+bootstrap: check-env roles-override
 	ansible-playbook ${ANSIBLE_DIR}/bootstrap.yml \
 		-i ${ENV_DIR}/gen/terraform-inventory.yml \
 		-i ${ENV_DIR}/inventory \

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -5,7 +5,7 @@
         # NOTE: stick with the default but expose it outside of Kubespray
         artifacts_dir: "{{ inventory_dir }}/artifacts"
 
-- import_playbook: roles-external/kubespray/cluster.yml
+- import_playbook: "{{ lookup('first_found', ['roles-override/kubespray/cluster.yml', 'roles-external/kubespray/cluster.yml']) }}"
 
 - name: 'Bringing kubeconfig in place'
   hosts: k8s-cluster


### PR DESCRIPTION
Please note that this is meant to only exist temporarily until we have a
solid release cycle for the platform in place. Regardless, overriding the
Kubespray version, defined by the the submodule pinning, from within ENV_DIR
should be avoided at all costs.