### PR TITLE
helm/Makefile: Ensure decrypted kubeconfig is only readable by user

### DIFF
--- a/helm/Makefile
+++ b/helm/Makefile
@@ -41,6 +41,7 @@ decrypt: kubeconfig.dec
 kubeconfig.dec: check-env-dir
 	@if [ ! -e $(ENV_DIR)/$(basename $(@)) ]; then exit 0; fi
 	sops -d $(ENV_DIR)/$(basename $(@)) > $(ENV_DIR)/$(@)
+	chmod 0600 $(ENV_DIR)/$(@)
 	@test -s $(ENV_DIR)/$(@) || (echo "[ERR] Failed decrypting kubeconfig" && exit 1)
 
 


### PR DESCRIPTION
This gets rid warning from helm:

```
  WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /tmp/build/b0d51b9f/cailleach/environments/anta/kubeconfig.dec

  WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /tmp/build/b0d51b9f/cailleach/environments/anta/kubeconfig.dec

```