### PR TITLE
[ansible] Revert local plays back to use implicit localhost

### DIFF
--- a/ansible/provision-sft.yml
+++ b/ansible/provision-sft.yml
@@ -1,12 +1,7 @@
 # This role requires access to s3 buckets and has a few variables that need to
 # be set. When run with any variables missing, it will complain about those
 # variables.
-# To replace hosts: localhost as suggested in http://willthames.github.io/2018/07/01/connection-local-vs-delegate_to-localhost.html
-- hosts: fakehost
-  connection: local
-  vars:
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-  gather_facts: no
+- hosts: localhost
   roles:
     - role: sft-monitoring-certs
       when: "{{ (groups['sft_servers'] | length) > 0 }}"
@@ -30,11 +25,7 @@
         group: root
         state: link
 
-- hosts: fakehost
-  connection: local
-  vars:
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-  gather_facts: no
+- hosts: localhost
   tasks:
     - when: "{{ (groups['sft_servers'] | length) > 0 }}"
       block:


### PR DESCRIPTION
at the moment CD skips fakehost plays, because it's not in the inventory;
defining some stub is not a nice solution, if the default (implicit)
works just fine. I guess we will find out shortly.

* this might only work properly with Nix when using Ansible >= v2.9
  but that is just a guess atm. We may need to go back to Ansible 2.7
  here
* partially reverting #415; current guess is that the error "boto
  required for this module" mentioned in the PR came form running
  it locally