### PR TITLE
[ansible] Add missing python packages when running a play on localhost

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -7,7 +7,11 @@ self: super: {
     ];
   }));
 
-  pythonForAnsible = (self.python3.withPackages (_: self.ansible.requiredPythonModules));
+  pythonForAnsible = (self.python3.withPackages (_: self.ansible.requiredPythonModules ++ [
+                                                                                             super.python3Packages.boto
+                                                                                             super.python3Packages.boto3
+                                                                                             super.python3Packages.six
+                                                                                           ] ));
 
   kubectl = self.callPackage ./pkgs/kubectl.nix { };
   kubernetes-helm = super.wrapHelm super.kubernetes-helm {


### PR DESCRIPTION
This is a follow-up to #441 (7b87f3b), which now causes `Failed to import the required Python library (botocore or boto3) on 9e8418a6-7fac-4c3c-4cc7-20e71ab37e0a's Python /nix/store/yl69v76azrz4daiqksrhb8nnmdiqdjg9-python3-3.8.8/bin/python3.8`

There is `python3-3.8.8` and `python3-3.8.8-env` in the Nix store. The latter has its own python in `./bin`.  `Ansible` resides in `/nix/store/...-wire-server-deploy/bin`, in the same location can also `python3 -> /nix/store/ni0cziyqgjk7fkb69ypg3gbjcq11bsnh-python3-3.8.8-env/bin/python3` be found.

While `/nix/store/yl69v76azrz4daiqksrhb8nnmdiqdjg9-python3-3.8.8/lib/python3.8/site-packages/` only contains `sitecustomize.py`, `/nix/store/ni0cziyqgjk7fkb69ypg3gbjcq11bsnh-python3-3.8.8-env/lib/python3.8/site-packages/` does contain actual packages like `bcrypt`, but no `boto*`.

When running this play
```
- hosts: localhost
  tasks:
    - debug:
        var: ansible_playbook_python
    - debug:
        var: ansible_python_interpreter
```
it results in

```
TASK [debug] *****************************************************************
ok: [localhost] => {
    "ansible_playbook_python": "/nix/store/yl69v76azrz4daiqksrhb8nnmdiqdjg9-python3-3.8.8/bin/python3.8"
}

TASK [debug] *****************************************************************
ok: [localhost] => {
    "ansible_python_interpreter": "/nix/store/yl69v76azrz4daiqksrhb8nnmdiqdjg9-python3-3.8.8/bin/python3.8"
}
```

The python interpreter used when invoking Ansible and when running a play
locally appears to be the same, but Ansible's dependencies reside within
its own venv, and are thus not visible when running a play on localhost.

