### PR TITLE
Fix ansible module dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,11 +1,13 @@
-env="$(nix-build $PWD/default.nix -A env --no-out-link)"
+nix-build $PWD/default.nix -A env --out-link .nix-env
 
-PATH_add "${env}/bin"
+PATH_add ".nix-env/bin"
+
+export LOCALHOST_PYTHON="$PWD/.nix-env/bin/python"
 
 # source .profile from `$env`.
 # This is only used to set things interpolated by nix.
 # All *static* things should live inside .envrc.
-[[ -f "${env}/.profile" ]] && source_env "${env}/.profile"
+[[ -f ".nix-env/.profile" ]] && source_env ".nix-env/.profile"
 
 # allow local .envrc overrides
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ values-init-done
 result
 result-*
 
+.nix-env
+
 # for bin/secrets.sh
 secrets_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ COPY . /wire-server-deploy
 
 RUN apk add -u bash git
 
-RUN nix-env -f /wire-server-deploy/default.nix -iA env
+RUN nix-build /wire-server-deploy/default.nix -A env --out-link /.nix-env
 
 RUN rm -rf /wire-server-deploy
+
+ENV PATH="/.nix-env/bin:$PATH"
+ENV LOCALHOST_PYTHON="/.nix-env/bin/python"
+

--- a/ansible/host_vars/localhost/python.yml
+++ b/ansible/host_vars/localhost/python.yml
@@ -1,1 +1,1 @@
-ansible_python_interpreter: $LOCALHOST_PYTHON
+ansible_python_interpreter: "{{ lookup('env','LOCALHOST_PYTHON') }}"

--- a/ansible/host_vars/localhost/python.yml
+++ b/ansible/host_vars/localhost/python.yml
@@ -1,0 +1,1 @@
+ansible_python_interpreter: $LOCALHOST_PYTHON

--- a/default.nix
+++ b/default.nix
@@ -15,13 +15,17 @@ let
     '';
   };
 
+  pythonForAnsible = pkgs.python3.withPackages (p: [ p.boto p.boto3 p.six p.cryptography ]);
+
+
 in {
   inherit pkgs profileEnv;
 
   env = pkgs.buildEnv{
     name = "wire-server-deploy";
     paths = with pkgs; [
-      ansible_with_libs
+      ansible_2_9
+      pythonForAnsible
       apacheHttpd
       awscli
       gnumake
@@ -33,7 +37,6 @@ in {
       kubectl
       openssl
       moreutils
-      pythonForAnsible
       skopeo
       sops
       terraform_0_13

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,14 +1,4 @@
 self: super: {
-  ansible_with_libs = super.python3Packages.toPythonApplication (super.python3Packages.ansible.overridePythonAttrs (old: rec {
-    propagatedBuildInputs = old.propagatedBuildInputs or [] ++ [
-      super.python3Packages.boto
-      super.python3Packages.boto3
-      super.python3Packages.six
-    ];
-  }));
-
-  pythonForAnsible = (self.python3.withPackages (_: self.ansible.requiredPythonModules));
-
   kubectl = self.callPackage ./pkgs/kubectl.nix { };
   kubernetes-helm = super.wrapHelm super.kubernetes-helm {
     plugins = with super.kubernetes-helmPlugins; [ helm-s3 helm-secrets helm-diff ];


### PR DESCRIPTION
What we were doing before was way too complicated. Ansible itself
doesn't have any dependency on boto to function. The _target host_
needs to have boto installed.

In our case the target host is 'localhost'.  Ansible will by default
pick /usr/bin/python3 as the python interpreter ogit n target hosts but of
course we can't rely on that having boto installed.

Instead, we configure ansible_python_interpreter to point to the
environment we built with nix; which contains a python that has boto
installed.

This way boto can be found and the playbooks should succeed!