### PR TITLE
[tooling] Merge [Terraform,Ansible,Helm] Makefile user interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,6 @@ $(TF_DATA_DIR):
 re-init: check-inputs-terraform
 	make --always-make $(TF_DATA_DIR)
 
-# NOTE: alias for 're-init'
-.PHONY: init
-.SILENT: init
-init:
-init:
-	echo "[WARN] 'make init' is deprecated. Please use re-init moving forward"
-	make re-init
-
 .PHONY: apply plan console destroy
 apply plan console destroy: check-inputs-terraform $(TF_DATA_DIR)
 	cd $(TERRAFORM_WORKING_DIR) \
@@ -160,7 +152,7 @@ kubeconfig.dec: check-env-dir
 		test -s $(ENV_DIR)/$(@) || (echo "[ERR] Decryption failed: $(basename $(@))" && exit 1) \
 	)
 
-.PHONY: clean
+.PHONY: clean-decrypt
 clean-decrypt: check-env-dir
 	rm $(ENV_DIR)/*.dec
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,201 @@
+SHELL := /usr/bin/env bash -eo pipefail
+MKFILE_DIR := $(abspath $(dir $(abspath $(firstword $(MAKEFILE_LIST)))))
+
+# NOTE: variables that can be defined/overwritten
+#ENV_DIR or ENV
+
+# NOTE: internal variables
+# Please ignore the following line if you're not a Wire employee
+ENVIRONMENTS_DIR := $(abspath $(CURDIR)/../cailleach/environments)
+
+
+
+ifndef ENV_DIR
+ifndef ENV
+$(error "[ERR] Undefined variable: Please define either ENV or ENV_DIR")
+else
+ENV_DIR = $(ENVIRONMENTS_DIR)/$(ENV)
+endif
+endif
+
+
+
+######################################## TERRAFORM #############################
+export TF_DATA_DIR = $(ENV_DIR)/.terraform
+TERRAFORM_WORKING_DIR = $(MKFILE_DIR)/terraform/environment
+
+
+# NOTE: leverage make's ability to noop if target already exists, but
+#       this also means that re-init must be triggered explicitly
+$(TF_DATA_DIR):
+	cd $(TERRAFORM_WORKING_DIR) \
+	&& terraform init -backend-config=$(ENV_DIR)/backend.tfvars
+
+.PHONY: re-init
+re-init: check-inputs-terraform
+	make --always-make $(TF_DATA_DIR)
+
+# NOTE: alias for 're-init'
+.PHONY: init
+.SILENT: init
+init:
+init:
+	echo "[WARN] 'make init' is deprecated. Please use re-init moving forward"
+	make re-init
+
+.PHONY: apply plan console destroy
+apply plan console destroy: check-inputs-terraform $(TF_DATA_DIR)
+	cd $(TERRAFORM_WORKING_DIR) \
+	&& source $(ENV_DIR)/hcloud-token.dec \
+	&& terraform $(@) -var-file=$(ENV_DIR)/terraform.tfvars
+
+# FUTUREWORK: as of TF v0.14 second argument (MKFILE_DIR) is not supported anymore
+.PHONY: force-unlock
+force-unlock:
+ifndef LOCK_ID
+	$(error "[ERR] Undefined variable: LOCK_ID")
+endif
+	cd $(TERRAFORM_WORKING_DIR) \
+	&& terraform force-unlock $(LOCK_ID) $(MKFILE_DIR)
+
+.PHONY: output
+output: check-inputs-terraform $(TF_DATA_DIR)
+	cd $(TERRAFORM_WORKING_DIR) \
+	&& terraform output -json
+
+.PHONY: create-inventory
+create-inventory: check-inputs-terraform $(TF_DATA_DIR)
+	mkdir -p $(ENV_DIR)/gen
+	cd $(TERRAFORM_WORKING_DIR) \
+	&& terraform output -json inventory > $(ENV_DIR)/gen/terraform-inventory.yml
+
+
+######################################## ANSIBLE ###############################
+ANSIBLE_DIR = $(MKFILE_DIR)/ansible
+export ANSIBLE_CONFIG = $(ANSIBLE_DIR)/ansible.cfg
+
+
+.PHONY: bootstrap
+bootstrap: check-inputs-ansible
+	ansible-playbook $(ANSIBLE_DIR)/bootstrap.yml \
+		-i $(ENV_DIR)/gen/terraform-inventory.yml \
+		-i $(ENV_DIR)/inventory \
+		--private-key $(ENV_DIR)/operator-ssh.dec \
+		-vv
+
+.PHONY: provision-sft
+provision-sft: check-inputs-ansible
+	ansible-playbook $(ANSIBLE_DIR)/provision-sft.yml \
+		-i $(ENV_DIR)/gen/terraform-inventory.yml \
+		-i $(ENV_DIR)/inventory \
+		--private-key $(ENV_DIR)/operator-ssh.dec \
+		-vv
+
+# FUTUREWORK: https://github.com/zinfra/backend-issues/issues/1763
+.PHONY: kube-minio-static-files
+kube-minio-static-files: check-inputs-ansible check-inputs-helm
+	ansible-playbook $(ANSIBLE_DIR)/kube-minio-static-files.yml \
+		-i $(ENV_DIR)/gen/terraform-inventory.yml \
+		-i $(ENV_DIR)/inventory \
+		--private-key $(ENV_DIR)/operator-ssh.dec \
+		--extra-vars "service_cluster_ip=$$(KUBECONFIG=$(ENV_DIR)/kubeconfig.dec kubectl get service fake-aws-s3 -o json | jq -r .spec.clusterIP)" \
+		-vv
+
+.PHONY: get-logs
+get-logs: LOG_DIR ?= $(ENV_DIR)
+get-logs: check-inputs-ansible
+	ansible-playbook $(ANSIBLE_DIR)/get-logs.yml \
+		-i $(ENV_DIR)/gen/terraform-inventory.yml \
+		-i $(ENV_DIR)/inventory \
+		--private-key $(ENV_DIR)/operator-ssh.dec \
+		--extra-vars "log_host=$(LOG_HOST)" \
+		--extra-vars "log_service=$(LOG_SERVICE)" \
+		--extra-vars "log_since='$(LOG_SINCE)'" \
+		--extra-vars "log_until='$(LOG_UNTIL)'" \
+		--extra-vars "log_dir=$(LOG_DIR)"
+
+
+
+######################################## HELM ##################################
+.PHONY: deploy
+deploy: check-inputs-helm
+	KUBECONFIG=$(ENV_DIR)/kubeconfig.dec \
+	helmfile \
+		--file $(ENV_DIR)/helmfile.yaml \
+		sync \
+			--concurrency 1
+
+
+
+######################################## CREDENTIALS ###########################
+
+.PHONY: decrypt
+decrypt: hcloud-token.dec operator-ssh.dec kubeconfig.dec
+
+.PHONY: hcloud-token.dec
+.SILENT: hcloud-token.dec
+hcloud-token.dec: check-env-dir
+	[ ! -e $(ENV_DIR)/$(basename $(@)) ] && exit 0 \
+	|| ( \
+		sops -d $(ENV_DIR)/$(basename $(@)) > $(ENV_DIR)/$(@) || rm $(ENV_DIR)/$(@); \
+		test -s $(ENV_DIR)/$(@) || (echo "[ERR] Decryption failed: $(basename $(@))" && exit 1) \
+	)
+
+.PHONY: operator-ssh.dec
+.SILENT: operator-ssh.dec
+operator-ssh.dec: check-env-dir
+	[ ! -e $(ENV_DIR)/$(basename $(@)) ] && exit 0 \
+	|| ( \
+		sops -d $(ENV_DIR)/$(basename $(@)) > $(ENV_DIR)/$(@) || rm $(ENV_DIR)/$(@); \
+		test -s $(ENV_DIR)/$(@) || (echo "[ERR] Decryption failed: $(basename $(@))" && exit 1); \
+		chmod 0600 $(ENV_DIR)/$(@) \
+	)
+
+.PHONY: kubeconfig.dec
+.SILENT: kubeconfig.dec
+kubeconfig.dec: check-env-dir
+	[ ! -e $(ENV_DIR)/$(basename $(@)) ] && exit 0 \
+	|| ( \
+		sops -d $(ENV_DIR)/$(basename $(@)) > $(ENV_DIR)/$(@) || rm $(ENV_DIR)/$(@); \
+		test -s $(ENV_DIR)/$(@) || (echo "[ERR] Decryption failed: $(basename $(@))" && exit 1) \
+	)
+
+.PHONY: clean
+clean-decrypt: check-env-dir
+	rm $(ENV_DIR)/*.dec
+
+
+
+######################################## Fail-safes ############################
+
+.PHONY: check-env-dir
+check-env-dir: $(ENV_DIR)
+$(ENV_DIR):
+	$(error "[ERR] Directory does not exist: $(@)")
+
+
+.PHONY: check-inputs-terraform
+check-inputs-terraform: $(ENV_DIR)/hcloud-token.dec
+
+$(ENV_DIR)/hcloud-token.dec:
+	$(error "[ERR] File does not exist: $(@)")
+
+
+.PHONY: check-inputs-ansible
+check-inputs-ansible: $(ENV_DIR)/inventory $(ENV_DIR)/gen/terraform-inventory.yml $(ENV_DIR)/operator-ssh.dec
+
+$(ENV_DIR)/inventory:
+	$(error "[ERR] Directory does not exist: $(@)")
+
+$(ENV_DIR)/gen/terraform-inventory.yml:
+	$(error "[ERR] File does not exist: $(@) - It's generated from Terraform output")
+
+$(ENV_DIR)/operator-ssh.dec:
+	$(error "[ERR] File does not exist: $(@) - It must contain the private key to ssh into servers")
+
+
+.PHONY: check-inputs-helm
+check-inputs-helm: $(ENV_DIR)/kubeconfig.dec
+
+$(ENV_DIR)/kubeconfig.dec:
+	$(error "[ERR] File does not exist: $(@) - Ensure that Kubernetes is installed")

--- a/ansible/get-logs.yml
+++ b/ansible/get-logs.yml
@@ -1,17 +1,33 @@
 - hosts: "{{ log_host }}"
   tasks:
+    - assert:
+        msg: "'log_host' must be set and not empty"
+        that:
+          - log_host is defined
+          - log_host | length > 0
+    - assert:
+        msg: "'log_service' must be set and not empty"
+        that:
+          - log_service is defined
+          - log_service | length > 0
+    - assert:
+        msg: "'log_since' must be set and not empty"
+        that:
+          - log_since is defined
+          - log_since | length > 0
+
     - name: get logs
-      shell: journalctl -u {{ log_service }} --since '{{ log_since }}' --until '{{ log_until }}'
+      shell: journalctl -u {{ log_service }} --since '{{ log_since }}' --until '{{ log_until | default('now', true) }}'
       register: the_logs
     - name: create logs directory
       delegate_to: localhost
       become: no
       file:
         state: directory
-        path: "{{ log_dir | default('/tmp', true) }}"
+        path: "{{ log_dir | default('./', true) }}"
     - name: save logs
       delegate_to: localhost
       become: no
       copy:
-        dest: "{{ log_dir | default('/tmp', true) }}/{{log_host}}-{{ log_service }}-{{ log_since }}-{{ log_until }}.log"
+        dest: "{{ log_dir | default('/tmp', true) }}/{{log_host}}-{{ log_service }}-{{ log_since }}-{{ log_until | default('now', true) }}.log"
         content: "{{ the_logs.stdout }}"


### PR DESCRIPTION
To prevent duplication, simplify maintainability and prevent version drift, this
change set aims to merge existing Makefiles into one located at the root of the
code base.

The resulting Makefile introduces a concepts of target dependencies (see `check-*`),
which are certain files or folders put in place by a previous step (e.g. Terraform
generates an inventory consumed by Ansible targets). Thus, running `make decrypt`
is still required, but the `check-inputs-*` will check whether the decrypted version
already exist, and errors if not.

* adds asserts to log extraction playbook to get rid of native make conditions; set
  local default location to ENV_DIR
* the necessity of setting ENV or ENV_DIR did not change; it's just that the check
  has been moved to the top of the Makefile. This way make fails as early as possible
* targets abstracting Terraform invocations now require the '.terraform' folder to
  exist, which implies `terraform init` to be invoked upfront, if '.terraform/' is
  not already there. Also, `make init` was renamed to `make re-init` due to the
  described implicit behaviour.


### Follw-up Tasks
* [ ] adjust CICD code to use the new Makefile
* [ ] adjust READMEs
* [ ] pick and migrate from https://github.com/wireapp/wire-server-deploy/pull/432
* [ ] remove the original Makefiles
