### PR TITLE
[ansible] Fix minio playbook execution when secret or key contain '$'

### DIFF
--- a/ansible/kube-minio-static-files.yml
+++ b/ansible/kube-minio-static-files.yml
@@ -15,7 +15,7 @@
         tasks_from: install-client
 
     - name: "add 'local' mc config alias with correct credentials"
-      shell: "mc config host add local http://{{ service_cluster_ip }}:9000 {{ minio_access_key }} {{ minio_secret_key }}"
+      shell: "mc config host add local http://{{ service_cluster_ip }}:9000 '{{ minio_access_key }}' '{{ minio_secret_key }}'"
 
     - name: "create 'public' bucket"
       shell: "mc mb --ignore-existing local/public"

--- a/ansible/minio.yml
+++ b/ansible/minio.yml
@@ -51,7 +51,7 @@
       tags: bucket-create
 
     - name: "add 'local' mc config alias with correct credentials"
-      shell: "mc config host add local http://localhost{{ minio_layouts.server1.server_addr }} {{ minio_access_key }} {{ minio_secret_key }}"
+      shell: "mc config host add local http://localhost{{ minio_layouts.server1.server_addr }} '{{ minio_access_key }}' '{{ minio_secret_key }}'"
       tags: mc-config
 
     - name: "make the 'public' bucket world-accessible"


### PR DESCRIPTION
Ansible shell task behaves as expected and would interpret '$'. Single-quoting
it fixes that.

Related: https://github.com/wireapp/ansible-minio/pull/6