### PR TITLE
Release: 2021-06-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,21 @@
 
 ## Features
 
-## versions
+## Fixes
+
+## Versions
 
 ## Breaking changes
 
 -->
 
+
+# 2021-06-16
+
+## Fixes
+
+* [Ansible] Prevent Minio installation from breaking when access or secret key contains `$`
+* [CI] Ensure that the right version of wire-server is built into the air-gap bundle
 
 
 # 2021-06-10

--- a/ansible/kube-minio-static-files.yml
+++ b/ansible/kube-minio-static-files.yml
@@ -15,7 +15,7 @@
         tasks_from: install-client
 
     - name: "add 'local' mc config alias with correct credentials"
-      shell: "mc config host add local http://{{ service_cluster_ip }}:9000 {{ minio_access_key }} {{ minio_secret_key }}"
+      shell: "mc config host add local http://{{ service_cluster_ip }}:9000 '{{ minio_access_key }}' '{{ minio_secret_key }}'"
 
     - name: "create 'public' bucket"
       shell: "mc mb --ignore-existing local/public"

--- a/ansible/minio.yml
+++ b/ansible/minio.yml
@@ -51,7 +51,7 @@
       tags: bucket-create
 
     - name: "add 'local' mc config alias with correct credentials"
-      shell: "mc config host add local http://localhost{{ minio_layouts.server1.server_addr }} {{ minio_access_key }} {{ minio_secret_key }}"
+      shell: "mc config host add local http://localhost{{ minio_layouts.server1.server_addr }} '{{ minio_access_key }}' '{{ minio_secret_key }}'"
       tags: mc-config
 
     - name: "make the 'public' bucket world-accessible"

--- a/bin/offline-deploy.sh
+++ b/bin/offline-deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # HACK: hack to stop ssh from idling the connection. Which it will do if there is no output. And ansible is not verbose enough

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -101,19 +101,18 @@ wire_version="2.106.0"
 # Download zauth; as it's needed to generate certificates
 echo "quay.io/wire/zauth:$wire_version" | create-container-dump containers-adminhost
 
-mkdir -p charts
-for chart in "${charts[@]}"; do
-  (cd charts; helm pull --version "$wire_version" --untar "$chart")
+mkdir -p ./charts
+for chartName in "${charts[@]}"; do
+  (cd ./charts; helm pull --version "$wire_version" --untar "$chartName")
 done
 
-for chart in "${charts[@]}"; do
-  echo "$chart"
+for chartPath in "$(pwd)"/charts/*; do
+  echo "$chartPath"
 done | list-helm-containers | create-container-dump containers-helm
 
 tar cf containers-helm.tar containers-helm
 [[ "$INCREMENTAL" -eq 0 ]] && rm -r containers-helm
 
-#
 echo "docker_ubuntu_repo_repokey: '${fingerprint}'" > ansible/inventory/offline/group_vars/all/key.yml
 
 


### PR DESCRIPTION
## Fixes

* [Ansible] Prevent Minio installation from breaking when access or secret key contains `$`
* [CI] Ensure that the right version of wire-server is built into the air-gap bundle