### PR TITLE
actually fix nested values for prometheus-operator (cf. #420)

### DIFF
--- a/values/wire-server-metrics/demo-values.example.yaml
+++ b/values/wire-server-metrics/demo-values.example.yaml
@@ -4,10 +4,11 @@
 #   grafana:
 #     persistence:
 #       enabled: false
-# prometheusSpec:
-#   storageSpec: null
-# alertmanager:
-#   alertmanagerSpec:
+#   prometheus:
+#     prometheusSpec:
+#       storageSpec: null
+#   alertmanager:
+#     alertmanagerSpec:
 #       storage: null
 
 
@@ -17,14 +18,15 @@
 #   grafana:
 #     persistence:
 #       storageClassName: "<my-storage-class>"
-# prometheusSpec:
-#   storageSpec: 
-#     volumeClaimTemplate:
-#       spec:
-#         storageClassName: "<my-storage-class>"
-# alertmanager:
-#   alertmanagerSpec:
-#     storage:
-#       volumeClaimTemplate:
-#         spec:
-#           storageClassName: "<my-storage-class>"
+#   prometheus:
+#     prometheusSpec:
+#       storageSpec: 
+#         volumeClaimTemplate:
+#           spec:
+#             storageClassName: "<my-storage-class>"
+#   alertmanager:
+#     alertmanagerSpec:
+#       storage:
+#         volumeClaimTemplate:
+#           spec:
+#             storageClassName: "<my-storage-class>"


### PR DESCRIPTION
This time the components' config trees are actually correctly nested under `prometheus-operator` and their respective top levels (e.g. `prometheus`).

For reference, see the [values file](https://github.com/helm/charts/blob/9c2bd6d59c33ddca798e549f3030439465f3f094/stable/prometheus-operator/values.yaml#L1143-L1251) of `prometheus-operator` at the time.

Fix-up for #420.