### PR TITLE
Pin Elastic Search to 6.6.0

### DIFF
--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -9,6 +9,7 @@
 
     # Put a hold on the ES package.
     # Updating ES to a different version than 6.6 currently breaks its integration with Wire.
+    es_version: "6.6.0"
     es_version_lock: true
 
     es_enable_xpack: false


### PR DESCRIPTION
Without specifying a version, the latest version of elastic search gets installed (`7.9.3` today), but we're not ready to support it yet.  