### PR TITLE
Simplify SNS platform creation by splitting up in two resources

### DIFF
--- a/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
@@ -1,104 +1,43 @@
-# Create platform applications for iOS and Android.
-
-locals {
-
-  # NOTE: Well, well, well, we got ourselves yet another 'bug' - or more precisely - an unexpected
-  #       behaviour. One would think, that
-  #
-  #           concat(var.ios_applications, var.android_applications)
-  #
-  #       would be the plausible choice for this task, but no, here comes Terraform.
-  #       'Hold my beer', it says: https://github.com/hashicorp/terraform/issues/26090
-  #       tl;dr It eats all the fields that are NOT part of the items's intersection
-  #       because different types. Admittedly, a reasonable explanation, but unexpected
-  #       nonetheless. In order to work around it, we are pulling out the iron.
-  applications = flatten([var.ios_applications, var.android_applications])
-
-  # NOTE: What is a platform? AWS lingua for all the different push notification services (see comment in the resource)
-  #       This nested iteration replaces each entry of 'applications' with a list of application <-> platform
-  #       combinations and adds the 'platform' field to each of them
-  # EXAMPLE:
-  #  [
-  #    [
-  #      {
-  #        id = "com.myapp"
-  #        platform = "APNS"
-  #        platforms = ["APNS","APNS_VOIP"]
-  #        key = "REDACTED"
-  #        cert = "REDACTED"
-  #      },
-  #      {
-  #        id = "com.myapp"
-  #        platform = "APNS_VOIP"
-  #        platforms = ["APNS","APNS_VOIP"]
-  #        key = "REDACTED"
-  #        cert = "REDACTED"
-  #      }
-  #    ],
-  #    [
-  #      {
-  #        id = "123456789"
-  #        platform = "GCM"
-  #        platforms = ["GCM"]
-  #        key = "REDACTED"
-  #        cert = "REDACTED"
-  #      }
-  #    ]
-  #  ]
-  #
-  app_platforms_lists = [
-    for _, app in local.applications : [
-      for _, platform in app.platforms : merge(app, { platform = platform })
-    ]
-  ]
-
-  # NOTE: get rid of the nested lists being generated
-  flattened_app_platforms_list = flatten(local.app_platforms_lists)
-
-  # NOTE: converts in to a map with the following identifier syntax: '${id}-${platform}'
-  #       for each application <-> platform combination
-  # EXAMPLE:
-  #  {
-  #    "com.myapp-APNS" = {
-  #      id = "com.myapp"
-  #      platform = "APNS"
-  #      platforms = ["APNS","APNS_VOIP"]
-  #      key = "REDACTED"
-  #      cert = "REDACTED"
-  #    },
-  #    ...
-  #  }
-  #
-  app_platforms_map = {
-    for _, app_platform in local.flattened_app_platforms_list
-      : "${app_platform.id}-${app_platform.platform}" => app_platform
-  }
-
-}
-
-resource "aws_sns_platform_application" "apps" {
-  for_each = local.app_platforms_map
+resource "aws_sns_platform_application" "ios" {
+  for_each = toset(var.ios_applications)
 
   # The name of the app is IMPORTANT! If it does not follow the pattern, then apps will not be able
   # to register for push notifications
-  # [iOS] More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
-  # [Android] More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
-  #
+  # More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#ios
   name = "${var.environment}-${each.value.id}"
-  # ^-- [iOS] <env>-<bundleID>
-  # ^-- [Android] <env>-<projectID>
+  # ^-- <env>-<bundleID>
   #  <env> should match the env on gundeck's config
   #  <bundleID> name of the application, which is bundled/hardcoded when the app is built
+  # NOTE: possible values https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html#sns-attrib-mobile-reserved
+  platform = each.value.platform
+
+  platform_credential = each.value.key
+  # ^-- Content of to the private key
+  platform_principal = each.value.cert
+  # ^-- Content of the public certificate
+
+  event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
+  # ^-- Topic to subscribe to
+  event_endpoint_updated_topic_arn = aws_sns_topic.device_state_changed.arn
+  # ^-- Topic to subscribe to
+}
+
+resource "aws_sns_platform_application" "android" {
+  for_each = toset(var.android_applications)
+
+  # The name of the app is IMPORTANT! If it does not follow the pattern, then apps will not be able
+  # to register for push notifications
+  # [Android] More details: https://github.com/zinfra/backend-wiki/wiki/Native-Push-Notifications#android
+  name = "${var.environment}-${each.value.id}"
+  # ^-- [Android] <env>-<projectID>
+  #  <env> should match the env on gundeck's config
   #  <projectID> name of the firebase project (this is unique across all firebase projects)
 
   # NOTE: possible values https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html#sns-attrib-mobile-reserved
   platform = each.value.platform
 
   platform_credential = each.value.key
-  # ^-- [iOS] Content of to the private key
-  # ^-- [Android] Content of the secret token
-  platform_principal = lookup(each.value, "cert", null)
-  # ^-- [iOS] Content of the public certificate
+  # ^-- The access token
 
   event_delivery_failure_topic_arn = aws_sns_topic.device_state_changed.arn
   # ^-- Topic to subscribe to


### PR DESCRIPTION
Instead of fighting Terraform by first differentiating into two resource types, to then merge them, and then split them up again;  just create a resource per application type.  The types then magically line up; and makes the code way easier to read in my opinion.

What I don't know is if this refactoring can be applied without downtime. But the reduction in complexity seems worth it.

Perhaps this needs some state surgery with `terraform state mv`  to move the respective apps into the `ios` and `android` resource