### PR TITLE
[tf-module:push-notifications]: make success_feedback_sample_rate configurable

### DIFF
--- a/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/resources.sns.tf
@@ -104,6 +104,8 @@ resource "aws_sns_platform_application" "apps" {
   # ^-- Topic to subscribe to
   event_endpoint_updated_topic_arn = aws_sns_topic.device_state_changed.arn
   # ^-- Topic to subscribe to
+
+  success_feedback_sample_rate = var.success_feedback_sample_rate
 }
 
 # Create topics and queues to publish push notifications

--- a/terraform/modules/aws-gundeck-push-notifications/variables.tf
+++ b/terraform/modules/aws-gundeck-push-notifications/variables.tf
@@ -20,7 +20,7 @@ variable "ios_applications" {
     cert      = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_principal
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
-  default = []
+  default     = []
 }
 
 
@@ -32,7 +32,13 @@ variable "android_applications" {
     key       = string # docs: https://www.terraform.io/docs/providers/aws/r/sns_platform_application.html#platform_credential
   }))
   description = "list of iOS applications and their credentials to be registered for push notifications (SNS)"
-  default = []
+  default     = []
+}
+
+variable "success_feedback_sample_rate" {
+  type        = number
+  description = "The success_feedback_sample_rate parameter set for applications"
+  default     = null
 }
 
 


### PR DESCRIPTION
    This allows setting this value to arbitrary values. Resources manually
    imported with `terraform import` might have this set to a value. Without
    a possibility to set this, subsequent `terraform apply` runs will
    complain about not being able to remove this field.
    
    Set this to the default value, instead of trying to fix this bug in the
    aws provider.