### PR TITLE
.github/workflows/ci.yml: bump versions of install-nix-action and cachix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/cachix-action@v10
         with:
           name: wire-server-deploy
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - run: nix-build -A env
-      - name: Check terraform init 
-        run: | 
+      - name: Check terraform init
+        run: |
           export PATH=$(nix-build -A env --no-out-link)/bin:$PATH
           cd terraform/environment
           terraform init --backend=false

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v14.1
     - name: Niv update
       run: |
         nix run -f . niv -c niv update

--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/cachix-action@v10
         with:
           name: wire-server-deploy
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"


### PR DESCRIPTION
Right now, the cachix-action uses the experimental feature `nix-command`.

With a bump of Nix to 2.4, this started to fail.