### PR TITLE
adding basic minio/deeplink variables

### DIFF
--- a/ansible/inventory/demo/hosts.example.ini
+++ b/ansible/inventory/demo/hosts.example.ini
@@ -42,3 +42,9 @@ docker_dns_servers_strict = False
 [k8s-cluster:vars]
 kube_network_plugin = flannel
 kubeconfig_localhost = True
+
+[minio:vars]
+prefix = "example-"
+domain = "example.com"
+deeplink_title = "example.com environment"
+

--- a/ansible/inventory/offline/99-static
+++ b/ansible/inventory/offline/99-static
@@ -65,6 +65,9 @@
 
 [minio:vars]
 # minio_network_interface = enp1s0
+prefix = "example-"
+domain = "example.com"
+deeplink_title = "example.com environment"
 
 [restund:vars]
 # Uncomment if your public IP is not on the default gateway

--- a/ansible/inventory/prod/hosts.example.ini
+++ b/ansible/inventory/prod/hosts.example.ini
@@ -61,6 +61,9 @@ minio03
 [minio:vars]
 minio_access_key = "REPLACE_THIS_WITH_THE_DESIRED_ACCESS_KEY"
 minio_secret_key = "REPLACE_THIS_WITH_THE_DESIRED_SECRET_KEY"
+prefix = "example-"
+domain = "example.com"
+deeplink_title = "example.com environment"
 
 [restund]
 restund01


### PR DESCRIPTION
As per JCT-65:

« our minio playbooks support :
```
minio.yml:      prefix: "{{ minio_deeplink_prefix | default('example-') }}"
minio.yml:      domain: "{{ minio_deeplink_domain | default('example.com') }}"
minio.yml:      deeplink_title: "{{ minio_deeplink_domain | default('example.com environment') }}"
```

add these variables to our ansible hosts.ini examples, and detail them in all three deployment instruction sets. »