### PR TITLE
Fix deps workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,12 @@ jobs:
         with:
           name: wire-server-deploy
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
-      - run: nix-build -A env
+
+      - name: Build the environment
+        run: nix-build -A env
+      - name: Install the environment
+        run: nix-env -f . -A env -i
       - name: Check terraform init
         run: |
-          export PATH=$(nix-build -A env --no-out-link)/bin:$PATH
           cd terraform/environment
           terraform init --backend=false

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -9,14 +9,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v14.1
+    - name: Build the environment
+      run: nix-build -A env
+    - name: Install the environment
+      run: nix-env -f . -A env -i
     - name: Niv update
       run: |
-        nix run -f . niv -c niv update
+        niv update
     - name: Container update
       run: |
-        nix run -f . nix-prefetch-docker -c nix-prefetch-docker alpine --image-tag 3 > ./nix/docker-alpine.nix
-    - name: Try build
-      run: nix-build -A env
+        nix-prefetch-docker -c nix-prefetch-docker alpine --image-tag 3 > ./nix/docker-alpine.nix
 
     # TODO: This won't trigger further CI runs yet unless we have a Personal
     # Access Token. Github limitation. Hence we're running `nix-build -A env`

--- a/default.nix
+++ b/default.nix
@@ -47,7 +47,9 @@ rec {
       mirror-apt
       generate-gpg1-key
       kubeadm
-    ] ++ [ profileEnv];
+
+      niv
+    ] ++ [ profileEnv ];
   };
 
   # The container we use for offline deploys. Where people probably do not have


### PR DESCRIPTION
The `deps` workflow was failing, as the experimental nix command changed (and we shouldn't use it).

This uses `nix-env` to install the environment, and invokes commands from there.