### PR TITLE
.github/workflows/ci.yml: remove macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
We don't need to build this for MacOS anymore.