### PR TITLE
other(elasticsearch): Bump Elasticsearch to 6.8.18 #FS-62

### DIFF
--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -8,7 +8,7 @@
     es_heap_size: "1g"
 
     # Put a hold on the ES package.
-    # Updating ES to a different version than 6.6 currently breaks its integration with Wire.
+    # Updating ES to a different version 7.x currently breaks its integration with Wire.
     es_version: "6.8.18"
     es_version_lock: true
 

--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -9,7 +9,7 @@
 
     # Put a hold on the ES package.
     # Updating ES to a different version than 6.6 currently breaks its integration with Wire.
-    es_version: "6.6.0"
+    es_version: "6.8.18"
     es_version_lock: true
 
     es_enable_xpack: false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Elasticsearch version is bumped to 6.8.18

### Issues

Our test environment has diverged from the ansible setup.

### Causes (Optional)


wireapp/wire-server#1952 needed to bump elasticsearch version in our testing
environment to 6.8.18 so we can use the same for kibana.

### Solutions

As wire-server is already compatible with this version, we can upgrade to this version safely. 
Also, this is the only 6.x version which gets updates from elastic, so we should be using it anyway.

### Dependencies (Optional)

wireapp/wire-server#1952

### Testing

I haven't tested it. How can I test this?

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] ~Wire's Github Workflow has automatically linked the PR to a JIRA issue~
    I did this manually
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
