### PR TITLE
Add new cargohold federationDomain setting

### DIFF
--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -89,6 +89,8 @@ cargohold:
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
       s3DownloadEndpoint: https://assets.example.com
+    settings:
+      federationDomain: example.com # change this
 #    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -121,6 +121,8 @@ cargohold:
       s3Bucket: assets
       s3Endpoint: http://minio-external:9000
       s3DownloadEndpoint: https://assets.example.com
+    settings:
+      federationDomain: example.com # change this
 #    proxy:
 #      httpProxy: "http://proxy.example.com"
 #      httpsProxy: "https://proxy.example.com"


### PR DESCRIPTION
Add new example federationDomain for cargohold. See https://github.com/wireapp/wire-server/pull/1990 and https://github.com/zinfra/cailleach/pull/767.
