### PR TITLE
Improve process control in offline deploy script

### DIFF
--- a/bin/offline-deploy.sh
+++ b/bin/offline-deploy.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 (while true; do echo "Still deploying..."; sleep 10; done) &
 loop_pid=$!
 
+trap 'kill "$loop_pid"' EXIT
+
 ZAUTH_CONTAINER=$(sudo docker load -i $SCRIPT_DIR/../containers-adminhost/quay.io_wire_zauth_*.tar | awk '{print $3}')
 export ZAUTH_CONTAINER
 
@@ -19,6 +21,4 @@ WSD_CONTAINER=$(sudo docker load -i $SCRIPT_DIR/../containers-adminhost/containe
 
 sudo docker run --network=host -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -v $PWD:/wire-server-deploy $WSD_CONTAINER ./bin/offline-cluster.sh
 sudo docker run --network=host -v $PWD:/wire-server-deploy $WSD_CONTAINER ./bin/offline-helm.sh
-
-kill $loop_pid
 


### PR DESCRIPTION
The `bin/offline-deploy.sh` script uses a child process to keep the connection alive when it's run over ssh from another host. This change modifies the offline deploy script so that the child process is killed properly when the script exits abnormally, to prevent the keepalive process from persisting beyond the lifetime of its parent.
