### PR TITLE
Dockerfile: Avoid using apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nixos/nix
 
 COPY . /wire-server-deploy
 
-RUN apk add -u bash git
+RUN nix-env -iA nixpkgs.bash nixpkgs.git
 
 RUN nix-build /wire-server-deploy/default.nix -A env --out-link /.nix-env
 


### PR DESCRIPTION
nixos/nix isn't based on alpine anymore