### PR TITLE
.github/workflows: use `wire-server` cachix cache instead of `wire-server-deploy` one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: cachix/install-nix-action@v14.1
       - uses: cachix/cachix-action@v10
         with:
-          name: wire-server-deploy
+          name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: Build the environment

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: cachix/cachix-action@v10
+      with:
+        name: wire-server
+        signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
     - uses: cachix/install-nix-action@v14.1
     - name: Build the environment
       run: nix-build -A env

--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: cachix/install-nix-action@v14.1
       - uses: cachix/cachix-action@v10
         with:
-          name: wire-server-deploy
+          name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Install nix environment
         run: nix-env -f default.nix -iA env


### PR DESCRIPTION
This uses the `wire-server` cachix cache consistently.