### PR TITLE
fix(ansible) Jb support etcdctl 3.14 (SER-44/SER-45)

### DIFF
--- a/ansible/roles/etcd-helpers/templates/etcd-health.sh.j2
+++ b/ansible/roles/etcd-helpers/templates/etcd-health.sh.j2
@@ -2,4 +2,4 @@
 
 HOST={{ ansible_hostname }}
 
-etcdctl --endpoints https://127.0.0.1:2379 --ca-file=/etc/ssl/etcd/ssl/ca.pem --cert-file=/etc/ssl/etcd/ssl/member-$HOST.pem --key-file=/etc/ssl/etcd/ssl/member-$HOST-key.pem --debug cluster-health
+etcdctl --endpoints https://127.0.0.1:2379 --ca-file=/etc/ssl/etcd/ssl/ca.pem --cert-file=/etc/ssl/etcd/ssl/member-$HOST.pem --key-file=/etc/ssl/etcd/ssl/member-$HOST-key.pem endpoint --cluster health

--- a/ansible/roles/etcd-helpers/templates/etcdctl3.sh.j2
+++ b/ansible/roles/etcd-helpers/templates/etcdctl3.sh.j2
@@ -7,4 +7,7 @@ export ETCDCTL_CA_FILE=/etc/ssl/etcd/ssl/ca.pem
 export ETCDCTL_CERT=/etc/ssl/etcd/ssl/member-$HOST.pem
 export ETCDCTL_KEY=/etc/ssl/etcd/ssl/member-$HOST-key.pem
 
+#to support etcdctl 3.14
+export ETCDCTL_CACERT=/etc/ssl/etcd/ssl/ca.pem
+
 /usr/local/bin/etcdctl "$@"


### PR DESCRIPTION
If merged, this PR will fix the issues described in SER-44 and SER-45 : 

* the "cluster-health" parameter is not valid anymore with etcdctl APIv3
* the ETCDCTL_CA_FILE env variable does not work with etcdctl 3.14

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
