### PR TITLE
Make Python versions consistent in Nix overlay

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,12 +1,12 @@
 self: super: {
   pythonForAnsible = (self.python3.withPackages (_: self.ansible.requiredPythonModules ++ [
-    super.python38Packages.boto
-    super.python38Packages.boto3
-    super.python38Packages.cryptography
-    super.python38Packages.six
+    super.python3Packages.boto
+    super.python3Packages.boto3
+    super.python3Packages.cryptography
+    super.python3Packages.six
     # for packet debugging and reporting.
-    super.python38Packages.pyshark
-    super.python38Packages.matplotlib
+    super.python3Packages.pyshark
+    super.python3Packages.matplotlib
   ]));
 
   kubectl = self.callPackage ./pkgs/kubectl.nix { };


### PR DESCRIPTION
The Nix overlay was updated in #544 to remove the pin of Python 3.8 specifically and to use the default version of Python 3 in nixpkgs, which is Python 3.9 just now. However, the list of bundled modules wasn't updated accordingly, which results in the Nix environment containing a 3.9 interpreter with a series of 3.8 modules which it can't use. This breaks things which e.g. try to use the version of Ansible bundled in the Nix environment in the Dockerfile to upload files to S3, which breaks because no compatible boto library can be found.