### PR TITLE
Add skip_kubeconfig_copying flag (SER-43)

### DIFF
--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -22,10 +22,11 @@
     - delegate_to: localhost
       block:
       - name: "Checking if 'kubeconfig' file already exists"
+        when: skip_kubeconfig_copying is undefined or skip_kubeconfig_copying == false
         stat:
           path: "{{ inventory_dir }}/../kubeconfig"
         register: file_kubeconfig
-      - when: not file_kubeconfig.stat.exists
+      - when: (skip_kubeconfig_copying is undefined or skip_kubeconfig_copying == false) and (not file_kubeconfig.stat.exists)
         block:
         - name: 'Renaming kubeconfig file provided by Kubespray'
           copy:


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds a new flag (`skip_kubeconfig_copying`) that skips the tasks related to copying the newly created `kubeconfig.dec` file to the local folder.

### Issues

This was wished by Orange, because otherwise the related tasks throw
errors in their environment.

Please see https://wearezeta.atlassian.net/browse/SER-43

### Solutions

Skipping is implemented by `when` clauses (conditionals).


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

I created a new environment in `cailleach` (`sven-test`) and tested these three states:
- Flag missing -> `kubeconfig.dec` was copied
- Flag `true` -> `kubeconfig.dec` **not** copied
- Flag `false` -> `kubeconfig.dec` was copied

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
