### PR TITLE
feat: Add fetch-kubeconfig playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,17 @@ renew-certs: check-inputs-ansible
 		-vv
 	mv $(ANSIBLE_DIR)/kubeconfig.new ${ENV_DIR}/
 
+# Usage: ENV=bella make create-inventory fetch-kubeconfig
+# Then encrypt the new kubeconfig with sops
+.PHONY: fetch-kubeconfig
+fetch-kubeconfig: check-inputs-ansible
+	ansible-playbook ${ANSIBLE_DIR}/kubernetes-fetch-kubeconfig.yml \
+		-i ${ENV_DIR}/gen/terraform-inventory.yml \
+		-i ${ENV_DIR}/inventory \
+		--private-key ${ENV_DIR}/operator-ssh.dec \
+		-vv
+	mv $(ANSIBLE_DIR)/kubeconfig.new ${ENV_DIR}/
+
 .PHONY: provision-sft
 provision-sft: check-inputs-ansible
 	ansible-playbook $(ANSIBLE_DIR)/provision-sft.yml \

--- a/ansible/kubernetes-fetch-kubeconfig.yml
+++ b/ansible/kubernetes-fetch-kubeconfig.yml
@@ -1,0 +1,17 @@
+# Fetch the `kubeconfig` file. This is useful when the original `kubeconfig` has
+# been lost.
+# Run it with e.g. `ENV=bella make create-inventory fetch-kubeconfig`.
+
+- name: 'Fetch kubeconfig'
+  hosts: kube-master
+  tasks:
+    - name: download kubeconfig
+      ansible.builtin.fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: ./kubeconfig.new
+        flat: true
+
+    - name: notify user about kubeconfig
+      ansible.builtin.debug:
+        msg:
+          - "./kubeconfig.new has been downloaded to your machine"


### PR DESCRIPTION
It downloads the kubeconfig again. This is useful when it has been lost.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Due to some jumping back and forth between branches I lost the `kubeconfig` of an *cailleach* environment. This Ansible playbook fetches it again.

### Solutions

The issue is solved by a new Ansible playbook that copies the `/etc/kubernetes/admin.conf` from the remote master to the local machine. 

#### How to Test

I ran it with 

```sh
export ENV="secusmart-column-3"
export ENV_DIR="/home/sven/src/cailleach/environments/${ENV}"
make create-inventory fetch-kubeconfig
```
