### PR TITLE
generate-gpg1-key: describe usage, bump to 2y

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -23,6 +23,15 @@ self: super: {
       nativeBuildInputs = [ super.makeWrapper ];
     }
     ''
+      # This key isn't a secret (it's built and uploaded to the binary cache after all ;-) )
+      # It's created out of the necessity that apt wants to verify against a
+      # key
+      # It's set to expire 2y after its creation,
+      # or whenever this derivation is built again without having the result in the binary cache.
+      # The public part of the key is shipped with the offline bundle
+      # ($aptly_root/public/gpg).
+      # Bump the following timestamp to force a recreation: 2022-05-17
+
       install -Dm755 ${./scripts/generate-gpg1-key.sh} $out/bin/generate-gpg1-key
       # we *--set* PATH here, to ensure we don't pick wrong gpgs
       wrapProgram $out/bin/generate-gpg1-key --set PATH '${super.lib.makeBinPath (with self; [ bash coreutils gnupg1orig ])}'

--- a/nix/scripts/generate-gpg1-key.sh
+++ b/nix/scripts/generate-gpg1-key.sh
@@ -22,7 +22,7 @@ cat > "$GNUPGHOME"/keycfg <<EOF
   Subkey-Length: 2048
   Name-Real: Wire Swiss GmbH
   Name-Email: gpg@wire.com
-  Expire-Date: 6m
+  Expire-Date: 2y
   # Do a commit here, so that we can later print "done"
   %commit
   %echo done


### PR DESCRIPTION
    nix/overlay.nix: describe how we use this GPG key
    
    This key isn't a secret (it's built and uploaded to the binary cache
    after all ;-) ) It's created out of the necessity that apt wants to
    verify against a key.
    
    It's set to expire 2y after its creation,
    or whenever this derivation is built again without having the result in the binary cache.
    
    The public part of the key is shipped with the offline bundle
    ($aptly_root/public/gpg).

---

    nix/scripts/generate-gpg1-key.sh: bump expiry date to 2y
