### PR TITLE
Feat: Generate QR codes via teams API (SQPIT-1369)

### DIFF
--- a/examples/team-provisioning-qr-codes/README.md
+++ b/examples/team-provisioning-qr-codes/README.md
@@ -1,9 +1,9 @@
 EXAMPLE: Onboarding users with QR codes instead of emails
 =========================================================
 
-This example includes a bash script to automate the provisioning of users in a Wire
-team on a private server instance without users needing to be able to receive
-email.
+This example includes a bash script to automate the provisioning of users in a
+Wire team on a private server instance without users needing to be able to
+receive email.
 
 New users are invited to a team by a team administrator, who sends an invite
 link to each user's email address from the team settings page. When the user
@@ -20,8 +20,10 @@ instead of the public cloud instance).
 
 ## Usage
 
-This script assumes that the Wire server instance is deployed and
-functioning correctly. The operator requires needs to add the *team id* (which can be found on the `team-settings` webapp under the menu item `Customization`) to the galley server configuration setting `exposeInvitationURLsTeamAllowlist`.
+This script assumes that the Wire server instance is deployed and functioning
+correctly. The operator requires needs to add the *team id* (which can be found
+on the `team-settings` webapp under the menu item `Customization`) to the galley
+server configuration setting `exposeInvitationURLsTeamAllowlist`.
 
 The `qrencode` command line tool is used for generating the URL QR codes,
 and a LaTeX toolchain and the `latexmk` script are used for generating the
@@ -88,8 +90,8 @@ An example invocation of the script could look like this:
     example.com's Wire server.
     EOF
     $
-    $ export TEAM_ADMIN_EMAIL="gCkzC3AP@example.com"
-    $ export TEAM_ADMIN_PASSWORD="tIFfm5Hw"
+    $ export TEAM_ADMIN_EMAIL="someone@example.com"
+    $ export TEAM_ADMIN_PASSWORD="password"
     $ export TEAM_ID="9cabf984-7a35-4cd5-9891-850c64f9195a"
     $ export NGINZ_HOST="nginz-https.wire.example.com"
     $ export DEEPLINK_URL="https://assets.wire.example.com/public/deeplink.html"
@@ -100,5 +102,4 @@ An example invocation of the script could look like this:
 
 The generated PDF file for this user would then be
 `john.doe@nonexistent-domain.example.pdf`.
-
 

--- a/examples/team-provisioning-qr-codes/generate-user-pdf.sh
+++ b/examples/team-provisioning-qr-codes/generate-user-pdf.sh
@@ -3,8 +3,8 @@
 # The following environment variables must be set in order to query invitations
 # links via teams API and generate invite and deeplink QR codes:
 #
-# TEAM_ADMIN_EMAIL="gCkzC3AP@example.com"
-# TEAM_ADMIN_PASSWORD="tIFfm5Hw"
+# TEAM_ADMIN_EMAIL="someone@example.com"
+# TEAM_ADMIN_PASSWORD="password"
 # TEAM_ID="9cabf984-7a35-4cd5-9891-850c64f9195a"
 # NGINZ_HOST="nginz-https.wire.example.com"
 # DEEPLINK_URL="https://assets.wire.example.com/public/deeplink.html"


### PR DESCRIPTION
This is more convenient (and, hopefully more stable) than relying on database schemas and access.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Solves https://wearezeta.atlassian.net/browse/SQPIT-1369

### Solutions

I've adjusted the existing script that queried the database to query Wire's teams API. 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [x] ~~GitHub link to other pull request~~

### Testing

#### Test Coverage (Optional)

- [X] ~~I have added automated test to this contribution~~

#### How to Test

Run this
```sh
nix-shell -p qrencode texlive.combined.scheme-medium

export TEAM_ADMIN_EMAIL="gCkzC3AP@example.com"
export TEAM_ADMIN_PASSWORD="tIFfm5Hw"
export TEAM_ID="9cabf984-7a35-4cd5-9891-850c64f9195a"
export NGINZ_HOST="nginz-https.wire.example.com"
export DEEPLINK_URL="https://assets.wire.example.com/public/deeplink.html"
export INSTRUCTIONS=./instructions.txt

./generate-user-pdf.sh some-email-you-make-up@example.com
```

and scan (and check) the result codes of the created PDF file.

Please ask me for the correct values of `NGINZ_HOST` and `DEEPLINK_URL`. (The values provided here won't work.)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
