### PR TITLE
fix: Omit integration test containers in offline bundle (SQPIT-1357)

### DIFF
--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -111,9 +111,11 @@ done
 # This is needed to bundle it's image.
 sed -i -Ee 's/federator: false/federator: true/' "$(pwd)"/values/wire-server/prod-values.example.yaml
 
+# Get and dump required containers from Helm charts. Omit integration test
+# containers (e.g. `quay.io_wire_galley-integration_4.22.0`.)
 for chartPath in "$(pwd)"/charts/*; do
   echo "$chartPath"
-done | list-helm-containers | create-container-dump containers-helm
+done | list-helm-containers | grep -v "\-integration:" | create-container-dump containers-helm
 
 # Undo changes on wire-server values.yaml
 sed -i -Ee 's/federator: true/federator: false/' "$(pwd)"/values/wire-server/prod-values.example.yaml


### PR DESCRIPTION
There's no need to deliver our tests to customers. It only increases the artifact size.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We delivered integration test containers for `wire-server` in the offline bundle. This just increases the bundle's size and by this download times, extraction times...

### Solutions

A `grep` expression to filter the integration test containers names out when it comes to downloading the container images.

### Testing

#### Test Coverage (Optional)

The bundle is still deploy-able. This is shown by the CI.

#### How to Test

One could do an offline deployment. However, this has not been done, yet.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
