### PR TITLE
fix: Update GitHub CI Cachix actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v14.1
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/install-nix-action@v20
+      - uses: cachix/cachix-action@v12
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v14.1
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/install-nix-action@v20
+      - uses: cachix/cachix-action@v12
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v14.1
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/install-nix-action@v20
+      - uses: cachix/cachix-action@v12
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"


### PR DESCRIPTION
The CI was failing with strange cachix related errors.

[Ticket](https://wearezeta.atlassian.net/browse/SQPIT-1641)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Cachix support in our GitHub CI pipeline was broken.

Example: https://github.com/wireapp/wire-server-deploy/actions/runs/4311654988/jobs/7521414920#step:4:11

```
Error: Action failed with error: Error: Unable to locate executable file: cachix. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

### Solutions

As the `cachix` executable is managed by a third-party action, update it.

### Testing

#### Test Coverage (Optional)

It's self-validating as it's the base of our GitHub CI pipelines.

----