### PR TITLE
2. Update terraform modules

### DIFF
--- a/terraform/examples/create-infrastructure.tf
+++ b/terraform/examples/create-infrastructure.tf
@@ -20,7 +20,7 @@ resource "hcloud_ssh_key" "default" {
 resource "hcloud_server" "node" {
   count       = 3
   name        = "node${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx41"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -31,7 +31,7 @@ resource "hcloud_server" "node" {
 resource "hcloud_server" "etcd" {
   count       = 3
   name        = "etcd${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx41"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -42,7 +42,7 @@ resource "hcloud_server" "etcd" {
 resource "hcloud_server" "redis" {
   count       = 0
   name        = "redis${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx11"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -53,7 +53,7 @@ resource "hcloud_server" "redis" {
 resource "hcloud_server" "restund" {
   count       = 2
   name        = "restund${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx11"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -64,7 +64,7 @@ resource "hcloud_server" "restund" {
 resource "hcloud_server" "minio" {
   count       = 3
   name        = "minio${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx11"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -75,7 +75,7 @@ resource "hcloud_server" "minio" {
 resource "hcloud_server" "cassandra" {
   count       = 3
   name        = "cassandra${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx21"
   ssh_keys    = ["hetznerssh-key"]
 
@@ -86,7 +86,7 @@ resource "hcloud_server" "cassandra" {
 resource "hcloud_server" "elasticsearch" {
   count       = 3
   name        = "elasticsearch${count.index}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   server_type = "cx11"
   ssh_keys    = ["hetznerssh-key"]
 

--- a/terraform/examples/wire-server-deploy-offline-hetzner/main.tf
+++ b/terraform/examples/wire-server-deploy-offline-hetzner/main.tf
@@ -61,7 +61,7 @@ resource "hcloud_ssh_key" "adminhost" {
 resource "hcloud_server" "adminhost" {
   location    = "nbg1"
   name        = "adminhost-${random_pet.adminhost.id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx41"
   user_data   = <<-EOF
@@ -96,7 +96,7 @@ resource "random_pet" "assethost" {
 resource "hcloud_server" "assethost" {
   location    = "nbg1"
   name        = "assethost-${random_pet.assethost.id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx41"
   user_data   = local.disable_network_cfg
@@ -116,7 +116,7 @@ resource "hcloud_server" "restund" {
   count       = local.restund_count
   location    = "nbg1"
   name        = "restund-${random_pet.restund[count.index].id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx11"
   user_data   = local.disable_network_cfg
@@ -137,7 +137,7 @@ resource "hcloud_server" "kubenode" {
   count       = local.kubenode_count
   location    = "nbg1"
   name        = "kubenode-${random_pet.kubenode[count.index].id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx41"
   user_data   = local.disable_network_cfg
@@ -158,7 +158,7 @@ resource "hcloud_server" "cassandra" {
   count       = local.cassandra_count
   location    = "nbg1"
   name        = "cassandra-${random_pet.cassandra[count.index].id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx11"
   user_data   = local.disable_network_cfg
@@ -179,7 +179,7 @@ resource "hcloud_server" "elasticsearch" {
   count       = local.elasticsearch_count
   location    = "nbg1"
   name        = "elasticsearch-${random_pet.elasticsearch[count.index].id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx11"
   user_data   = local.disable_network_cfg
@@ -200,7 +200,7 @@ resource "hcloud_server" "minio" {
   count       = local.minio_count
   location    = "nbg1"
   name        = "minio-${random_pet.minio[count.index].id}"
-  image       = "ubuntu-18.04"
+  image       = "ubuntu-22.04"
   ssh_keys    = local.ssh_keys
   server_type = "cx11"
   user_data   = local.disable_network_cfg

--- a/terraform/modules/hetzner-kubernetes/machines.variables.tf
+++ b/terraform/modules/hetzner-kubernetes/machines.variables.tf
@@ -7,7 +7,7 @@ variable "default_server_type" {
 }
 
 variable "default_image" {
-  default = "ubuntu-18.04"
+  default = "ubuntu-22.04"
 }
 
 


### PR DESCRIPTION
Changes in the terraform modules, to use ubuntu 22 for hetzner test env.
This pr is an attempt to break down the update_to_ubuntu_22 branch changes into multiple prs.