### PR TITLE
also allow running the kubespray-based renew-certs playbook for k8s 1…

### DIFF
--- a/ansible/kubernetes-renew-certs.yml
+++ b/ansible/kubernetes-renew-certs.yml
@@ -2,8 +2,6 @@
 #
 # Run "make renew-certs" to execute this playbook.
 #
-# Beware! This script only works if there a single control plane node!
-#
 # Comments:
 #
 # > Step 6. Make kubelet aware of the new certificate
@@ -17,10 +15,6 @@
 - name: 'Renew certificates'
   hosts: kube-master
   tasks:
-    - name: fail if there is more than 1 master
-      fail:
-        msg: This playbook only works when there is one master node.
-      when: groups['kube-master'] | length > 1
     - name: create backup dir
       file:
         dest: "/etc/kubernetes/backup-before-cert-renew/"


### PR DESCRIPTION
….19 to work with multiple control plane nodes, as that also works.

Used this on calling-k8s-staging env, which has 3 control planes.