### PR TITLE
hide sensitive info from tf output

### DIFF
--- a/terraform/environment/inventory.tf
+++ b/terraform/environment/inventory.tf
@@ -7,4 +7,5 @@ output "inventory" {
     local.sft_inventory,
     local.k8s_cluster_inventory
   )
+  sensitive = true
 }


### PR DESCRIPTION
While trying to make a new test environment from cailleach(https://github.com/zinfra/cailleach/pull/1869)

and running command make apply command, I got the following error -


```
➜  wire-server-deploy git:(master) ✗ make apply

if [ -f /Users/asagtani/Wireapp/cailleach/environments/amit-sftd/custom.tf ]; then ln -sf /Users/asagtani/Wireapp/cailleach/environments/amit-sftd/custom.tf /Users/asagtani/Wireapp/wire-server-deploy/terraform/environment/custom.tf; else rm -f /Users/asagtani/Wireapp/wire-server-deploy/terraform/environment/custom.tf; fi
cd /Users/asagtani/Wireapp/wire-server-deploy/terraform/environment \
&& source /Users/asagtani/Wireapp/cailleach/environments/amit-sftd/hcloud-token.dec \
&& terraform apply -var-file=/Users/asagtani/Wireapp/cailleach/environments/amit-sftd/terraform.tfvars
╷
│ Error: Output refers to sensitive values
│ 
│   on inventory.tf line 5:
│    5: output "inventory" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to
│ be only internal, Terraform requires that any root module output containing
│ sensitive data be explicitly marked as sensitive, to confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by
│ adding the following argument:
│     sensitive = true
╵
make: *** [Makefile:49: apply] Error 1
```


Added the `sensitive = true` flag to fix the above issue.