### PR TITLE
[DO NOT MERGE]check backward compatibility on k8s 1.28 changes

### DIFF
--- a/bin/offline-helm.sh
+++ b/bin/offline-helm.sh
@@ -11,10 +11,17 @@ helm upgrade --install --wait demo-smtp ./charts/demo-smtp --values ./values/dem
 helm upgrade --install --wait rabbitmq ./charts/rabbitmq --values ./values/rabbitmq/prod-values.example.yaml --values ./values/rabbitmq/prod-secrets.example.yaml
 helm upgrade --install --wait databases-ephemeral ./charts/databases-ephemeral --values ./values/databases-ephemeral/prod-values.example.yaml
 helm upgrade --install --wait reaper ./charts/reaper
-helm upgrade --install --wait --timeout=15m0s wire-server ./charts/wire-server --values ./values/wire-server/prod-values.example.yaml --values ./values/wire-server/secrets.yaml
+helm upgrade --install --timeout=15m0s wire-server ./charts/wire-server --values ./values/wire-server/prod-values.example.yaml --values ./values/wire-server/secrets.yaml
+echo "[DEBUG]Sleeping for 1000 seconds to wait for the pods to come up"
+sleep 1000
 echo "Printing all pods status"
 kubectl get pods --all-namespaces -o wide
-helm upgrade --install --wait ingress-nginx-controller ./charts/ingress-nginx-controller --values ./values/ingress-nginx-controller/hetzner-ci.example.yaml
+echo "Printing all nodes status"
+kubectl get nodes -o wide
+helm upgrade --install ingress-nginx-controller ./charts/ingress-nginx-controller --values ./values/ingress-nginx-controller/hetzner-ci.example.yaml
+sleep 100
+echo "Printing all pods status"
+kubectl get pods --all-namespaces -o wide
 #./bin/debug_logs.sh
 # TODO: Requires certs; which we do not have in CI/CD at this point. future work =) (Would need cert-manager in offline package. That'd be neat)
 # helm upgrade --install --wait nginx-ingress-services ./charts/nginx-ingress-services --values ./values/nginx-ingress-services/values.yaml  --values ./values/nginx-ingress-services/secrets.yaml

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -101,16 +101,16 @@ calling_charts=(
 )
 
 # wire_version=$(helm show chart wire/wire-server | yq -r .version)
-wire_version="4.39.0"
+wire_version="4.39.159"
 
 # same as prior.. in most cases.
-wire_calling_version="4.39.0"
+wire_calling_version="4.39.159"
 
 # TODO: Awaiting some fixes in wire-server regarding tagless images
 HELM_HOME=$(mktemp -d)
 export HELM_HOME
 
-helm repo add wire https://s3-eu-west-1.amazonaws.com/public.wire.com/charts
+helm repo add wire https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-develop
 # Note: If you need to deploy something from the develop branch, uncomment the next line.
 #helm repo add wire-develop https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-develop
 helm repo update


### PR DESCRIPTION
Testing the backward compatibility for the changes made in the helm charts for kubernetes bump to 1.28