### PR TITLE
ci.sh : Add option to build from wire-builds

### DIFF
--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -137,6 +137,7 @@ wire_build_chart_release () {
 # on stdin
 pull_charts() {
   echo "Pulling charts into ./charts ..."
+  mkdir -p ./charts
 
   home=$(mktemp -d)
   export HELM_CACHE_HOME="$home"

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -135,7 +135,7 @@ wire_build_chart_release () {
   curl "$wire_build" | jq -r '.helmCharts | to_entries | map("\(.key) \(.value.repo) \(.value.version)") | join("\n") '
 }
 
-# pull_charts() accepts repos in format
+# pull_charts() accepts charts in format
 # <chart-name> <repo-url> <chart-version>
 # on stdin
 pull_charts() {

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -81,7 +81,7 @@ list-system-containers | create-container-dump containers-system
 tar cf containers-system.tar containers-system
 [[ "$INCREMENTAL" -eq 0 ]] && rm -r containers-system
 
-Used for ansible-restund role
+# Used for ansible-restund role
 echo "quay.io/wire/restund:v0.6.0-rc.2" | create-container-dump containers-other
 tar cf containers-other.tar containers-other
 [[ "$INCREMENTAL" -eq 0 ]] && rm -r containers-other
@@ -158,8 +158,7 @@ pull_charts() {
     repo=${parts[1]}
     version=${parts[2]}
 
-    # we pull the repo only the first time we see it
-    # to prevent pulling the same repo over and over again
+    # we add and update the repo only the first time we see it to speed up the process
     repo_short_name=${repos[$repo]}
     if [ "$repo_short_name" == "" ]; then
       n=${#repos[@]}

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -87,7 +87,7 @@ tar cf containers-other.tar containers-other
 [[ "$INCREMENTAL" -eq 0 ]] && rm -r containers-other
 
 legacy_chart_release() {
-  # Note: if you want to ship from the develop branch, replace 'wire' with 'wire-develop' below.
+  # Note: if you want to ship from the develop branch, replace 'repo' url below
   # repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-develop
   repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts
   wire_version="4.41.0"

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -178,6 +178,7 @@ legacy_chart_release | pull_charts
 # TODO: Awaiting some fixes in wire-server regarding tagless images
 
 # Download zauth; as it's needed to generate certificates
+wire_version=$(helm show chart ./charts/wire-server | yq -r .version)
 echo "quay.io/wire/zauth:$wire_version" | create-container-dump containers-adminhost
 
 ###################################

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -87,10 +87,9 @@ tar cf containers-other.tar containers-other
 [[ "$INCREMENTAL" -eq 0 ]] && rm -r containers-other
 
 legacy_chart_release() {
-  repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts
   # Note: if you want to ship from the develop branch, replace 'wire' with 'wire-develop' below.
   # repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-develop
-
+  repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts
   wire_version="4.41.0"
   wire_calling_version="4.40.0"
   
@@ -114,7 +113,6 @@ legacy_chart_release() {
     rabbitmq-external
     # federator
   )
-
   for chartName in "${charts[@]}"; do
     echo "$chartName $repo $wire_version"
   done
@@ -124,7 +122,6 @@ legacy_chart_release() {
     restund
     coturn
   )
-
   for chartName in "${calling_charts[@]}"; do
     echo "$chartName $repo $wire_calling_version"
   done


### PR DESCRIPTION
This PR extends `offline/ci.sh` so that it can pull helm charts listed in a build.json of https://github.com/wireapp/wire-builds

To build from wire-builds release just replace

```
legacy_chart_release | pull_charts
# wire_build_chart_release | pull_charts
```

with

```
# legacy_chart_release | pull_charts
wire_build_chart_release | pull_charts
```

and adjust the URL in wire_build_chart_release()

https://wearezeta.atlassian.net/browse/WPB-6028
