### PR TITLE
ldap-scim-bridge docs update and add bzip2 library

### DIFF
--- a/nix/scripts/mirror-apt-jammy.sh
+++ b/nix/scripts/mirror-apt-jammy.sh
@@ -68,6 +68,7 @@ packages=(
   vi
   tcpdump
   gnupg
+  bzip2
   # Dependencies for the rabbitmq-server package
   erlang-base
   erlang-asn1

--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -74,6 +74,7 @@ quay.io/metallb/controller:v0.13.9
 docker.io/library/nginx:1.25.2-alpine
 docker.io/kubernetesui/dashboard:v2.7.0
 docker.io/kubernetesui/metrics-scraper:v1.0.8
+quay.io/wire/ldap-scim-bridge:0.9
 EOF
 }
 

--- a/offline/ldap-scim-bridge.md
+++ b/offline/ldap-scim-bridge.md
@@ -1,11 +1,5 @@
 # How to deploy the ldap-scim-bridge
 
-Note: the LDAP Scim bridge is in a separate package at the moment. the docker container is available from: 
-
-https://temp-rhc-jun.s3.eu-west-1.amazonaws.com/ldap-scim-bridge%3A0.4.tar.bz2
-
-the helm chart is in wire-server.
-
 Create a values file
 mkdir values/ldap-scim-bridge_team-0
 the values file looks like the following:
@@ -45,16 +39,6 @@ config:
     email: "mail"
 ```
 
-When you get the package:
-
-Copy your values and charts folders into the `Wire-Server` directory you're using.
-
-Copy the container image to all of the kubernetes hosts in your cluster.
-
-Pre-seed the docker container for `ldap-scim-bridge` onto all of your kubernetes hosts.
-```
-sudo bash -c "cat ldap-scim-bridge:0.4.tar.bz2 | docker load"
-```
 
 ## Get the Active Directory root authority's public certificate
 

--- a/values/ldap-scim-bridge/values-prod.example.yaml
+++ b/values/ldap-scim-bridge/values-prod.example.yaml
@@ -1,3 +1,6 @@
+image:
+  repository: quay.io/wire/ldap-scim-bridge
+  tag: 0.9
 # NOTE: you will need an LDAP SCIM bridge deployment for each team!
 # by default, run every 5 minutes.
 schedule: "*/5 * * * * *"

--- a/values/ldap-scim-bridge/values-prod.example.yaml
+++ b/values/ldap-scim-bridge/values-prod.example.yaml
@@ -1,9 +1,6 @@
-image:
-  repository: quay.io/wire/ldap-scim-bridge
-  tag: 0.9
 # NOTE: you will need an LDAP SCIM bridge deployment for each team!
 # by default, run every 5 minutes.
-schedule: "*/5 * * * * *"
+schedule: "*/5 * * * *"
 config:
   logLevel: "Debug" # one of Trace,Debug,Info,Warn,Error,Fatal; 'Fatal' is least noisy, 'Trace' is most.
   ldapSource:
@@ -15,7 +12,7 @@ config:
     search:
       base: "DC=example,DC=com"
       objectClass: "person"
-      memberOf "CN=people,OU=engineering,DC=example,DC=com"
+      memberOf: "CN=people,OU=engineering,DC=example,DC=com"
     codec: "utf8"
     #    deleteOnAttribute:  # optional, related to delete-from-directory.
     #      key: "deleted"


### PR DESCRIPTION
WPB-7170

ldap-scim-bridge chart is now available in offline artifacts through wire-builds directly. Updating docs for the same.