### PR TITLE
exposing vars & dependencies for cassandra backups

### DIFF
--- a/ansible/hetzner-single-deploy.yml
+++ b/ansible/hetzner-single-deploy.yml
@@ -1,7 +1,7 @@
 - hosts: all
   become: true
   vars:
-    artifact_hash: 8054e59c8a40a6ac2cce2bbdbf4c80fa06d50e4b
+    artifact_hash: f97a141ff9484810164510bf872bd2033ec3e7ff
     ubuntu_version: 22.04.4
     ssh_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPTGTo1lTqd3Ym/75MRyQvj8xZINO/GI6FzfIadSe5c backend+hetzner-dedicated-operator@wire.com"
   tasks:

--- a/ansible/inventory/offline/99-static
+++ b/ansible/inventory/offline/99-static
@@ -74,6 +74,12 @@
 
 [cassandra:vars]
 # cassandra_network_interface = enp1s0
+# setting either cassandra backup directive to 'True' below requires a valid s3 bucket name as well
+# also, enabling backups will install `awscli` via pip, which requires an internet connection
+# cassandra_backup_enabled = False 
+# cassandra_incremental_backup_enabled = False
+# cassandra_backup_s3_bucket = <bucketname>
+
 
 [elasticsearch:vars]
 # elasticsearch_network_interface = enp1s0

--- a/nix/scripts/mirror-apt-jammy.sh
+++ b/nix/scripts/mirror-apt-jammy.sh
@@ -27,6 +27,7 @@ shift
 packages=(
   python3-apt
   python3-netaddr
+  python3-pip
   aufs-tools
   apt-transport-https
   software-properties-common

--- a/offline/docs_ubuntu_22.04.md
+++ b/offline/docs_ubuntu_22.04.md
@@ -313,11 +313,12 @@ ansnode3 ansible_host=192.168.122.33
 
 [all:vars]
 ansible_user = demo
-ansible_password = fai
-ansible_become_password = fai
 
 [cassandra:vars]
 cassandra_network_interface = enp1s0
+cassandra_backup_enabled = False
+cassandra_incremental_backup_enabled = False
+# cassandra_backup_s3_bucket = 
 
 [elasticsearch:vars]
 elasticsearch_network_interface = enp1s0


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-9154

Adding three new vars to ansible hosts.ini, exposing backup options in inventory.
Including dependencies needed to install `awscli` via `pip` used for cassandra backup scripts.
Updating offline docu readme.