### PR TITLE
Reintroduce Terraform

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,10 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
     inherit system;
-    config = { };
+    config = {
+      # To get Terraform (OpenTofu is not a full drop-in replacement)
+      allowUnfree = true;
+    };
     overlays = [
       (import ./nix/overlay.nix)
     ];
@@ -44,6 +47,7 @@ rec {
       moreutils
       skopeo
       sops
+      terraform
       opentofu
       yq
       create-container-dump


### PR DESCRIPTION
OpenTofu is not a full drop-in replacement: It fails when it queries additional Terraform providers from the registry for cailleach commands (e.g. `make re-init`.)

OpenTofu now runs its own registry which seems to not be a 1:1 copy of Terraform's.
