### PR TITLE
bring back dnsmasq to vms

### DIFF
--- a/ansible/hetzner-single-deploy.yml
+++ b/ansible/hetzner-single-deploy.yml
@@ -103,14 +103,11 @@
       owner: root
       group: root
     notify: sshd | restart
-  - name: Stop dnsmasq service
-    ansible.builtin.service:
+  - name: stop and disable dnsmasq service
+    service:
       name: dnsmasq
       state: stopped
-  - name: Disable dnsmasq service
-    ansible.builtin.service:
-      name: dnsmasq
-      enabled: no
+      enabled: false
   - name: collect libvirt network facts
     virt_net:
       command: facts

--- a/ansible/hetzner-single-deploy.yml
+++ b/ansible/hetzner-single-deploy.yml
@@ -103,6 +103,14 @@
       owner: root
       group: root
     notify: sshd | restart
+  - name: Stop dnsmasq service
+    ansible.builtin.service:
+      name: dnsmasq
+      state: stopped
+  - name: Disable dnsmasq service
+    ansible.builtin.service:
+      name: dnsmasq
+      enabled: no
   - name: collect libvirt network facts
     virt_net:
       command: facts

--- a/ansible/hetzner-single-deploy.yml
+++ b/ansible/hetzner-single-deploy.yml
@@ -27,6 +27,7 @@
       - debian-goodies
       - dnsutils
       - git
+      - dnsmasq
       - less
       - lsof
       - net-tools


### PR DESCRIPTION
hetzner-single-deploy playbook fails to setup WIAB env due to missing dnsmasq on host machine. Adding it back