### PR TITLE
bump cachix and nix github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: wire-server
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"


### PR DESCRIPTION
Current CI is broken due to old version of cachix and nix-build github action versions.

For example- - https://github.com/wireapp/wire-server-deploy/actions/runs/9496727324/job/26175408139?pr=710

this PR bumps the version and fixes the CI.