### PR TITLE
Fix "renew certs" for newer Kubespray clusters

### DIFF
--- a/ansible/kubernetes-renew-certs.yml
+++ b/ansible/kubernetes-renew-certs.yml
@@ -45,16 +45,16 @@
       ansible.builtin.shell: |
         set -eo pipefail
 
-        kubeadm alpha certs renew apiserver-kubelet-client
-        kubeadm alpha certs renew apiserver
-        kubeadm alpha certs renew front-proxy-client
-        kubeadm alpha kubeconfig user --client-name system:kube-controller-manager > /etc/kubernetes/controller-manager.conf
-        kubeadm alpha kubeconfig user --client-name system:kube-scheduler > /etc/kubernetes/scheduler.conf
+        kubeadm certs renew apiserver-kubelet-client
+        kubeadm certs renew apiserver
+        kubeadm certs renew front-proxy-client
+        kubeadm kubeconfig user --client-name system:kube-controller-manager --config /etc/kubernetes/kubeadm-config.yaml > /etc/kubernetes/controller-manager.conf
+        kubeadm kubeconfig user --client-name system:kube-scheduler --config /etc/kubernetes/kubeadm-config.yaml > /etc/kubernetes/scheduler.conf
         # note: if apiserver_loadbalancer_domain_name is not defined it might be that you talk to the cps directly
         # in that case replace {{ apiserver_loadbalancer_domain_name }} with the public ip / domain of the cps
-        kubeadm alpha kubeconfig user --client-name system:node:$(hostname) --org system:nodes --apiserver-advertise-address={{ apiserver_loadbalancer_domain_name }} > /etc/kubernetes/kubelet.conf
+        kubeadm kubeconfig user --client-name system:node:$(hostname) --org system:nodes --config /etc/kubernetes/kubeadm-config.yaml > /etc/kubernetes/kubelet.conf
 
-        kubeadm alpha kubeconfig user --client-name kubernetes-admin --org system:masters > /etc/kubernetes/admin.conf
+        kubeadm kubeconfig user --client-name kubernetes-admin --org system:masters --config /etc/kubernetes/kubeadm-config.yaml > /etc/kubernetes/admin.conf
 
     - debug:
         var: command_output.stdout_lines


### PR DESCRIPTION
The command line interface of `kubeadm`' changed a bit:
- Used commands aren't *alpha* anymore
- `--apiserver-advertise-address` is gone for `kubeconfig user` (it works as expected without)
- `--config` is required for `kubeconfig user`