### PR TITLE
Nix: Fix vendorSha256 warning

### DIFF
--- a/nix/pkgs/helm-mapkubeapis.nix
+++ b/nix/pkgs/helm-mapkubeapis.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-OIom+fMjLkbYXbxCsISuihdr3CWjUnkucTnDfoix9B0=";
   };
 
-  vendorSha256 = "sha256-jqVzBRlGFhDHaiSF9AArJdt4KRCiUqUuo0CnJUTbSfE=";
+  vendorHash = "sha256-jqVzBRlGFhDHaiSF9AArJdt4KRCiUqUuo0CnJUTbSfE=";
 
   # NOTE: Remove the install and upgrade hooks.
   postPatch = ''

--- a/nix/pkgs/kubernetes-tools.nix
+++ b/nix/pkgs/kubernetes-tools.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     hash = "sha256-7juoX4nFvQbIIbhTlnIYVUEYUJGwu+aKrpw4ltujjXI=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   doCheck = false;
 


### PR DESCRIPTION
Fixes `trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead`.