### PR TITLE
[SP1] remove internal-use helm charts

### DIFF
--- a/offline/ci.sh
+++ b/offline/ci.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 INCREMENTAL="${INCREMENTAL:-0}"
 
 # Default exclude list
-HELM_CHART_EXCLUDE_LIST="inbucket"
+HELM_CHART_EXCLUDE_LIST="aws-ingress,backoffice,calling-test,fluent-bit,inbucket,k8ssandra-test-cluster,kibana,nginx-ingress-controller,restund"
 
 # Parse the HELM_CHART_EXCLUDE_LIST argument
 for arg in "$@"


### PR DESCRIPTION
* filter out the following internal helm charts from the offline-bundle build:
  * `aws-ingress`
  * `backoffice`
  * `calling-test`
  * `inbucket`
  * `nginx-ingress-controller`
  * `k8ssandra-test-cluster`
  * `fluent-bit`
  * `kibana`
  * `restund`


relates to WPB-11283