### PR TITLE
WPB-17770: Pull cert-manager chart from wireapp helm_charts repo

### DIFF
--- a/offline/tasks/proc_pull_charts.sh
+++ b/offline/tasks/proc_pull_charts.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 OUTPUT_DIR=""
 # Default exclude lists
-HELM_CHART_EXCLUDE_LIST="inbucket,wire-server-enterprise"
+HELM_CHART_EXCLUDE_LIST="inbucket,wire-server-enterprise,cert-manager"
 
 # Parse the arguments
 for arg in "$@"
@@ -49,8 +49,9 @@ wire_build_chart_release () {
 # <chart-name> <repo-url> <chart-version>
 # on stdin
 pull_charts() {
-  echo "Pulling charts into ${OUTPUT_DIR}/charts ..."
-  mkdir -p "${OUTPUT_DIR}"/charts
+  local dest_dir="${1:-${OUTPUT_DIR}/charts}"
+  echo "Pulling charts into $dest_dir ..."
+  mkdir -p "$dest_dir"
 
   home=$(mktemp -d)
   export HELM_CACHE_HOME="$home"
@@ -78,10 +79,50 @@ pull_charts() {
       helm repo add "$repo_short_name" "$repo"
       helm repo update "$repo_short_name"
     fi
-    (cd "${OUTPUT_DIR}"/charts; helm pull --version "$version" --untar "$repo_short_name/$name")
+    # Check if the chart is already pulled
+    if [ -d "$dest_dir/$name" ]; then
+      echo "Chart directory $dest_dir/$name already exists, skipping pull."
+      continue
+    fi
+    echo "Pulling chart $name from $repo_short_name with version $version..."
+    helm pull --version "$version" --untar -d "$dest_dir" "$repo_short_name/$name"
   done
   echo "Pulling charts done."
 }
 
+pull_from_wire_helm_charts() {
+  local chart_name="$1"
+  local repo_owner="wireapp"
+  local repo_name="helm-charts"
+  local branch="cert-manager-in-bundle"  # Change to PR branch name if needed, e.g. "pull/27/head"
+  local output_dir="${OUTPUT_DIR}/charts"
+
+  echo "Fetching $chart_name chart from $repo_owner/$repo_name ($branch)..."
+
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  git clone --depth 1 --branch "$branch" "https://github.com/${repo_owner}/${repo_name}.git" "$tmp_dir"
+  if [[ -d "$tmp_dir/charts/$chart_name" ]]; then
+    mkdir -p "$output_dir"
+    cp -R "$tmp_dir/charts/$chart_name" "$output_dir/"
+    
+    # Parse the dependencies from the requirements.yaml file and pull them untarred
+    local requirements_file="$tmp_dir/charts/$chart_name/requirements.yaml"
+    if [[ -f "$requirements_file" ]]; then
+      echo "Parsing dependencies from $requirements_file..."
+      local dependencies=$(yq eval '.dependencies[] | "\(.name) \(.repository) \(.version)"' "$requirements_file")
+      echo "$dependencies" | pull_charts "$output_dir/$chart_name/charts"
+    else
+      echo "No requirements.yaml file found for $chart_name."
+    fi
+  else
+    echo "Chart '$chart_name' not found in repo."
+  fi
+  rm -rf "$tmp_dir"
+}
+
 wire_build="https://raw.githubusercontent.com/wireapp/wire-builds/6074076265c6b456330116574c11b12906f1c158/build.json"
 wire_build_chart_release "$wire_build" | pull_charts
+
+# Pulls the charts from https://github.com/wireapp/helm-charts
+pull_from_wire_helm_charts "cert-manager"


### PR DESCRIPTION
<!-- In case this addressed an existing issue 
Fixes ${ISSUE_URL}
-->

### Change type

<!-- choose the kind of change this PR introduces -->

* [ ] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Basic information 

* [ ] THIS CHANGE REQUIRES A DEPLOYMENT PACKAGE RELEASE
* [ ] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE

### Testing

* [ ] I ran/applied the changes myself, in a test environment.
* [ ] The CI job attached to this repo will test it for me.

### Tracking

* [ ] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.

### Knowledge Transfer
* [ ] An Asciinema session is attached to the Jira ticket.

### Motivation

<!--
What is the motivation for introducing this change?
Which scenario(s) is/are addressed by the change?
What problem does the change try to solve? 
-->
With this change we will have cert-manager helm charts and images in the offline bundle. So, when the cert-manager will be deployed to the cluster it does not need to pull the images from upstream.


### Objective

<!--
What kind behaviour does it change, add, or remove?
How did it behave before? How does it behave now? 
-->


### Reason

<!--
How did you fix the issue?
Why did you solve it this way? 
-->


### Use case

<!--
How is the change used? maybe share some example code.
Does the change introduce any incompatibility?
-->
