### PR TITLE
wire update

### DIFF
--- a/offline/tasks/proc_pull_charts.sh
+++ b/offline/tasks/proc_pull_charts.sh
@@ -94,5 +94,5 @@ pull_charts() {
   #fi
 }
 
-wire_build="https://raw.githubusercontent.com/wireapp/wire-builds/pinned-offline-multi-20260224-142104/build.json"
+wire_build="https://raw.githubusercontent.com/wireapp/wire-builds/20bb936ddcc589487e7bb3a7fc6f6c712803259c/build.json"
 wire_build_chart_release "$wire_build" | pull_charts


### PR DESCRIPTION
## Wire Server Version
- Version: `5.28.0`

---

**Note:** This PR updates the wire-builds reference in `offline/tasks/proc_pull_charts.sh`.

**See commit messages for detailed chart changes** - PR description cannot be auto-updated due to token permissions.

<sub>🤖 Auto-generated by [wire-builds](https://github.com/wireapp/wire-builds/actions/runs/22312876815)</sub>
