### PR TITLE
Enable MLS protocol in production values

### DIFF
--- a/changelog.d/3-deploy-builds/fix-mls-value
+++ b/changelog.d/3-deploy-builds/fix-mls-value
@@ -1,0 +1,1 @@
+Fixed: Enable MLS protocol in production values for brig

--- a/changelog.d/3-deploy-builds/fix-mls-value
+++ b/changelog.d/3-deploy-builds/fix-mls-value
@@ -1,1 +1,1 @@
-Fixed: Enable MLS protocol in production values for brig
+Fixed: Enable MLS protocol in production and dev values for brig

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -55,7 +55,7 @@ brig:
       teamMemberWelcome: https://wire.example.com/download # change this
     enableFederation: false # Keep false unless federation is explicitly configured
     optSettings:
-      setEnableMLS: false # Enable for MLS protocol use
+      setEnableMLS: true # Enable for MLS protocol use
       setFederationDomain: example.com # change this per host deployment
       # Sync the domain with the 'host' variable in the sftd chart
       # Comment the next line (by adding '#' before it) if conference calling is not used

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -55,7 +55,7 @@ brig:
       teamMemberWelcome: https://wire.example.com/download # change this
     enableFederation: false # Keep false unless federation is explicitly configured
     optSettings:
-      setEnableMLS: false # Enable for MLS protocol use
+      setEnableMLS: true # Enable for MLS protocol use
       setFederationDomain: example.com # change this per host deployment
       # Sync the domain with the 'host' variable in the sftd chart
       # Comment the next line (by adding '#' before it) if conference calling is not used


### PR DESCRIPTION
Mohit had me deploy a wire-server (wire in a box) install following the current instructions. The install itself went mostly well, but recently I tried to set up a new user and log into the webapp, and that produced an error related to MLS/Proteus. The fix was to change the brig config `setEnableMLS` to `true`, which caused the backend and frontend to "match". This is a commit aimed at creating a PR that fixes this issue moving forward.

### Change type

* [x] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Testing

* [x] I ran/applied the changes myself, in a test environment.
* [x] The CI job attached to this repo will test it for me.

### Tracking

* [x] I added a new entry in an appropriate subdirectory of `changelog.d`
* [x] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.
