### PR TITLE
Fix/rabbitmq inventory syntax

### DIFF
--- a/ansible/inventory/offline/99-static
+++ b/ansible/inventory/offline/99-static
@@ -83,7 +83,7 @@
 
 [postgresql:vars]
 postgresql_network_interface = enp1s0
-# repmgr_node_config is defined in group_vars/postgresql/repmgr_node_config.yml
+# repmgr_node_config is defined in group_vars/postgresql/postgresql.yml
 
 [elasticsearch:vars]
 # elasticsearch_network_interface = enp1s0
@@ -98,7 +98,9 @@ postgresql_network_interface = enp1s0
 
 # Rabbitmq specific variables
 [rmq-cluster:vars]
-# host name here must match each node's actual hostname
+# host name here must match each node's actual hostname (short hostname, not FQDN)
+# e.g. if the node's FQDN is rabbitmq1.example.com, use: rabbitmq_cluster_master = rabbitmq1
+# Using FQDN here will cause rabbitmqctl join_cluster to fail with a :badarg error
 rabbitmq_cluster_master = rabbitmq1
 # rabbitmq_network_interface = enp1s0
 

--- a/ansible/inventory/offline/99-static
+++ b/ansible/inventory/offline/99-static
@@ -83,19 +83,7 @@
 
 [postgresql:vars]
 postgresql_network_interface = enp1s0
-repmgr_node_config:
-  postgresql1:  # Maps to postgresql_rw group
-    node_id: 1
-    priority: 150
-    role: primary
-  postgresql2:  # Maps to first postgresql_ro
-    node_id: 2
-    priority: 100
-    role: standby
-  postgresql3:  # Maps to second postgresql_ro
-    node_id: 3
-    priority: 50
-    role: standby
+# repmgr_node_config is defined in group_vars/postgresql/repmgr_node_config.yml
 
 [elasticsearch:vars]
 # elasticsearch_network_interface = enp1s0
@@ -111,7 +99,7 @@ repmgr_node_config:
 # Rabbitmq specific variables
 [rmq-cluster:vars]
 # host name here must match each node's actual hostname
-rabbitmq_cluster_master: rabbitmq1
+rabbitmq_cluster_master = rabbitmq1
 # rabbitmq_network_interface = enp1s0
 
 # For the following groups, add all nodes defined above to the sections below.

--- a/ansible/inventory/offline/99-static
+++ b/ansible/inventory/offline/99-static
@@ -83,7 +83,6 @@
 
 [postgresql:vars]
 postgresql_network_interface = enp1s0
-# repmgr_node_config is defined in group_vars/postgresql/postgresql.yml
 
 [elasticsearch:vars]
 # elasticsearch_network_interface = enp1s0
@@ -101,7 +100,7 @@ postgresql_network_interface = enp1s0
 # host name here must match each node's actual hostname (short hostname, not FQDN)
 # e.g. if the node's FQDN is rabbitmq1.example.com, use: rabbitmq_cluster_master = rabbitmq1
 # Using FQDN here will cause rabbitmqctl join_cluster to fail with a :badarg error
-rabbitmq_cluster_master = rabbitmq1
+# rabbitmq_cluster_master = rabbitmq1
 # rabbitmq_network_interface = enp1s0
 
 # For the following groups, add all nodes defined above to the sections below.

--- a/ansible/inventory/offline/group_vars/postgresql/postgresql.yml
+++ b/ansible/inventory/offline/group_vars/postgresql/postgresql.yml
@@ -24,8 +24,22 @@ repmgr_namespace: "{{ wire_namespace | default('default') }}"
 wire_pg_secret_name: "wire-postgresql-external-secret"
 
 # Node configuration for repmgr
-# NOTE: repmgr_node_config is defined in the inventory file ansible/inventory/offline/99-static, ansible/inventory/offline/staging.yml and terraform/examples/wire-server-deploy-offline-hetzner/outputs.tf
-# to allow environment-specific node mappings. Do not define here.
+# NOTE: staging inventory and terraform-generated envs override this in their own vars:
+#   - ansible/inventory/offline/staging.yml
+#   - terraform/examples/wire-server-deploy-offline-hetzner/outputs.tf
+repmgr_node_config:
+  postgresql1:  # Maps to postgresql_rw group
+    node_id: 1
+    priority: 150
+    role: primary
+  postgresql2:  # Maps to first postgresql_ro
+    node_id: 2
+    priority: 100
+    role: standby
+  postgresql3:  # Maps to second postgresql_ro
+    node_id: 3
+    priority: 50
+    role: standby
 
 # repmgr settings
 # repmgrd monitoring and reconnection configuration

--- a/ansible/inventory/offline/group_vars/postgresql/postgresql.yml
+++ b/ansible/inventory/offline/group_vars/postgresql/postgresql.yml
@@ -23,23 +23,6 @@ repmgr_namespace: "{{ wire_namespace | default('default') }}"
 # This is managed alongside repmgr credentials in postgresql-secrets.yml
 wire_pg_secret_name: "wire-postgresql-external-secret"
 
-# Node configuration for repmgr
-# NOTE: staging inventory and terraform-generated envs override this in their own vars:
-#   - ansible/inventory/offline/staging.yml
-#   - terraform/examples/wire-server-deploy-offline-hetzner/outputs.tf
-repmgr_node_config:
-  postgresql1:  # Maps to postgresql_rw group
-    node_id: 1
-    priority: 150
-    role: primary
-  postgresql2:  # Maps to first postgresql_ro
-    node_id: 2
-    priority: 100
-    role: standby
-  postgresql3:  # Maps to second postgresql_ro
-    node_id: 3
-    priority: 50
-    role: standby
 
 # repmgr settings
 # repmgrd monitoring and reconnection configuration

--- a/ansible/templates/postgresql/repmgr.conf.j2
+++ b/ansible/templates/postgresql/repmgr.conf.j2
@@ -5,12 +5,12 @@
 # NODE IDENTIFICATION
 # Ref: https://www.repmgr.org/docs/current/configuration-file.html
 # ====================================================================
-{% set node_config = repmgr_node_config[inventory_hostname] | default({}) %}
-node_id={{ node_config.node_id | default(1) }}
+{% set _rw = groups['postgresql_rw'] | default([]) %}
+{% set _ro = groups['postgresql_ro'] | default([]) %}
+{% set _all_pg = _rw + _ro %}
+node_id={{ _all_pg.index(inventory_hostname) + 1 }}
 node_name='{{ inventory_hostname }}'
-{% if node_config.priority is defined %}
-priority={{ node_config.priority }}
-{% endif %}
+priority={{ 150 if inventory_hostname in _rw else ((_ro | length - _ro.index(inventory_hostname)) * 50) }}
 
 # ====================================================================
 # CONNECTION SETTINGS

--- a/ansible/templates/postgresql/simple_fence.sh.j2
+++ b/ansible/templates/postgresql/simple_fence.sh.j2
@@ -8,7 +8,8 @@ PGUSER="{{ repmgr_user }}"
 PGDATABASE="{{ repmgr_database }}"
 LOGFILE="/var/log/postgresql/fence_events.log"
 SCRIPT_NAME="simple_fence"
-LOCAL_NODE_ID="{{ repmgr_node_config[inventory_hostname].node_id if repmgr_node_config is defined and repmgr_node_config.get(inventory_hostname) and repmgr_node_config[inventory_hostname].get('node_id') else '1' }}"
+{% set _all_pg = groups['postgresql_rw'] | default([]) + groups['postgresql_ro'] | default([]) %}
+LOCAL_NODE_ID="{{ _all_pg.index(inventory_hostname) + 1 }}"
 
 # Node mappings (id → ip/name), generated from inventory if available
 declare -A NODE_HOSTS=({% set nodes = ((groups.postgresql_rw|default([])) + (groups.postgresql_ro|default([]))) -%}

--- a/changelog.d/5-bug-fixes/fix-rabbitmq-repmgr-inventory-syntax
+++ b/changelog.d/5-bug-fixes/fix-rabbitmq-repmgr-inventory-syntax
@@ -1,0 +1,1 @@
+Fixed: rabbitmq_cluster_master and repmgr_node_config syntax errors in offline inventory 99-static


### PR DESCRIPTION
<!-- In case this addressed an existing issue 
Fixes ${ISSUE_URL}
-->
- Fix rabbitmq_cluster_master using YAML colon syntax instead of INI
  key=value syntax, which caused Ansible parse warnings and the wrong
  node name being used when joining the RabbitMQ cluster
- Move repmgr_node_config from 99-static (INI, unsupported YAML dict)
  into group_vars/postgresql/postgresql.yml (proper YAML)
### Change type

<!-- choose the kind of change this PR introduces -->

* [x] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Basic information 

* [ ] THIS CHANGE REQUIRES A DEPLOYMENT PACKAGE RELEASE
* [ ] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE

### Testing

* [ ] I ran/applied the changes myself, in a test environment.
* [ ] The CI job attached to this repo will test it for me.

#### Offline Build CI (label-based)
Add one or more labels to trigger offline builds:
- `build-default` - Full production build (ansible, terraform, all packages)
- `build-dev` - WIAB/dev build
- `build-wiab-staging` - WIAB-staging build
- `build-min` - Minimal build (fastest, essential charts only)
- `build-all` - Run all three builds

**Note:** No builds run by default. Add a label to trigger CI.

### Tracking

* [ ] I added a new entry in an appropriate subdirectory of `changelog.d`
* [ ] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.

### Knowledge Transfer
* [ ] An Asciinema session is attached to the Jira ticket.

### Motivation

<!--
What is the motivation for introducing this change?
Which scenario(s) is/are addressed by the change?
What problem does the change try to solve? 
-->


### Objective

<!--
What kind behaviour does it change, add, or remove?
How did it behave before? How does it behave now? 
-->


### Reason

<!--
How did you fix the issue?
Why did you solve it this way? 
-->


### Use case

<!--
How is the change used? maybe share some example code.
Does the change introduce any incompatibility?
-->
