### PR TITLE
fix WPB-23445: update wire-builds reference for wire-server-5.28

### DIFF
--- a/changelog.d/2-wire-builds/wire-server-5.28
+++ b/changelog.d/2-wire-builds/wire-server-5.28
@@ -1,0 +1,1 @@
+Changed: the wire-builds reference for 2026-q1 with 5.28 backend

--- a/offline/tasks/proc_pull_charts.sh
+++ b/offline/tasks/proc_pull_charts.sh
@@ -94,5 +94,5 @@ pull_charts() {
   #fi
 }
 
-wire_build="https://raw.githubusercontent.com/wireapp/wire-builds/ecd204f07540e79fc1febe2483a42111129a5d0d/build.json"
+wire_build="https://raw.githubusercontent.com/wireapp/wire-builds/refs/heads/2026-q1/build.json"
 wire_build_chart_release "$wire_build" | pull_charts


### PR DESCRIPTION
<!-- In case this addressed an existing issue 
Fixes ${ISSUE_URL}
-->

### Change type

<!-- choose the kind of change this PR introduces -->

* [x] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Basic information 

* [x] THIS CHANGE REQUIRES A DEPLOYMENT PACKAGE RELEASE
* [ ] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE

### Testing

* [ ] I ran/applied the changes myself, in a test environment.
* [x] The CI job attached to this repo will test it for me.

#### Offline Build CI (label-based)
Add one or more labels to trigger offline builds:
- `build-default` - Full production build (ansible, terraform, all packages)
- `build-dev` - WIAB/dev build
- `build-wiab-staging` - WIAB-staging build
- `build-min` - Minimal build (fastest, essential charts only)
- `build-all` - Run all three builds

**Note:** No builds run by default. Add a label to trigger CI.

### Tracking

* [x] I added a new entry in an appropriate subdirectory of `changelog.d`
* [x] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.

### Knowledge Transfer
* [ ] An Asciinema session is attached to the Jira ticket.

### Motivation

<!--
What is the motivation for introducing this change?
Which scenario(s) is/are addressed by the change?
What problem does the change try to solve? 
-->


### Objective

<!--
What kind behaviour does it change, add, or remove?
How did it behave before? How does it behave now? 
-->


### Reason

<!--
How did you fix the issue?
Why did you solve it this way? 
-->


### Use case

<!--
How is the change used? maybe share some example code.
Does the change introduce any incompatibility?
-->
