### PR TITLE
fix: WPB-25755 remove old images not in use anymore

### DIFF
--- a/changelog.d/2-wire-builds/clean-old-system-images
+++ b/changelog.d/2-wire-builds/clean-old-system-images
@@ -1,0 +1,1 @@
+Removed: old images not in use anymore from proc_system_containers.sh

--- a/changelog.d/3-deploy-builds/fix-mls-value
+++ b/changelog.d/3-deploy-builds/fix-mls-value
@@ -1,0 +1,1 @@
+Fixed: Enable MLS protocol in production and dev values for brig

--- a/offline/tasks/proc_system_containers.sh
+++ b/offline/tasks/proc_system_containers.sh
@@ -32,14 +32,6 @@ quay.io/calico/pod2daemon-flexvol:v3.27.4
 quay.io/calico/kube-controllers:v3.27.4
 quay.io/calico/typha:v3.27.4
 quay.io/calico/apiserver:v3.27.4
-quay.io/jetstack/cert-manager-controller:v1.16.3
-quay.io/jetstack/cert-manager-cainjector:v1.16.3
-quay.io/jetstack/cert-manager-webhook:v1.16.3
-quay.io/jetstack/cert-manager-startupapicheck:v1.16.3
-docker.io/library/nginx:1.25.4-alpine
-bats/bats:1.11.1
-cr.step.sm/smallstep/step-ca:0.25.3-rc7
-registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
 EOF
 }
 

--- a/offline/tasks/proc_system_containers.sh
+++ b/offline/tasks/proc_system_containers.sh
@@ -32,6 +32,7 @@ quay.io/calico/pod2daemon-flexvol:v3.27.4
 quay.io/calico/kube-controllers:v3.27.4
 quay.io/calico/typha:v3.27.4
 quay.io/calico/apiserver:v3.27.4
+docker.io/library/nginx:1.25.4-alpine
 EOF
 }
 

--- a/values/wire-server/demo-values.example.yaml
+++ b/values/wire-server/demo-values.example.yaml
@@ -55,7 +55,7 @@ brig:
       teamMemberWelcome: https://wire.example.com/download # change this
     enableFederation: false # Keep false unless federation is explicitly configured
     optSettings:
-      setEnableMLS: false # Enable for MLS protocol use
+      setEnableMLS: true # Enable for MLS protocol use
       setFederationDomain: example.com # change this per host deployment
       # Sync the domain with the 'host' variable in the sftd chart
       # Comment the next line (by adding '#' before it) if conference calling is not used

--- a/values/wire-server/prod-values.example.yaml
+++ b/values/wire-server/prod-values.example.yaml
@@ -55,7 +55,7 @@ brig:
       teamMemberWelcome: https://wire.example.com/download # change this
     enableFederation: false # Keep false unless federation is explicitly configured
     optSettings:
-      setEnableMLS: false # Enable for MLS protocol use
+      setEnableMLS: true # Enable for MLS protocol use
       setFederationDomain: example.com # change this per host deployment
       # Sync the domain with the 'host' variable in the sftd chart
       # Comment the next line (by adding '#' before it) if conference calling is not used


### PR DESCRIPTION
remove old images not in use anymore from proc_system_containers.sh

```
bash-5.2# for img in 'docker.io/library/nginx:1.25.4-alpine' 'bats/bats:1.11.1' 'cr.step.sm/smallstep/step-ca:0.25.3-rc7' 'registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0' 'quay.io/jetstack/cert-manager-webhook:v1.16.3'; do   echo "=== $img ===";   kubectl get pods -A -o json | jq -r --arg IMG "$img" '
    .items[]
    | select(
        ([.spec.containers[]?.image, .spec.initContainers[]?.image] | any(. == $IMG))
      )
    | "\(.metadata.namespace)/\(.metadata.name)"
  '; done
=== docker.io/library/nginx:1.25.4-alpine ===
=== bats/bats:1.11.1 ===
=== cr.step.sm/smallstep/step-ca:0.25.3-rc7 ===
=== registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0 ===
=== quay.io/jetstack/cert-manager-webhook:v1.16.3 ===
cert-manager-ns/cert-manager-webhook-7494fb9bdd-b6fgn
```

following images are coming from cert-manager:
```
  {
    "chart": "cert-manager",
    "images": [
      "quay.io/jetstack/cert-manager-cainjector:v1.16.3",
      "quay.io/jetstack/cert-manager-controller:v1.16.3",
      "quay.io/jetstack/cert-manager-startupapicheck:v1.16.3",
      "quay.io/jetstack/cert-manager-webhook:v1.16.3"
    ]
  },
```

<!-- In case this addressed an existing issue 
Fixes ${ISSUE_URL}
-->

### Change type

<!-- choose the kind of change this PR introduces -->

* [x] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Basic information 

* [ ] THIS CHANGE REQUIRES A DEPLOYMENT PACKAGE RELEASE
* [ ] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE

### Testing

* [x] I ran/applied the changes myself, in a test environment.
* [x] The CI job attached to this repo will test it for me.

#### Offline Build CI (label-based)
Add one or more labels to trigger offline builds:
- `build-default` - Full production build (ansible, terraform, all packages)
- `build-dev` - WIAB/dev build
- `build-wiab-staging` - WIAB-staging build
- `build-min` - Minimal build (fastest, essential charts only)
- `build-all` - Run all three builds

**Note:** No builds run by default. Add a label to trigger CI.

### Tracking

* [x] I added a new entry in an appropriate subdirectory of `changelog.d`
* [x] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.

### Knowledge Transfer
* [ ] An Asciinema session is attached to the Jira ticket.

### Motivation

<!--
What is the motivation for introducing this change?
Which scenario(s) is/are addressed by the change?
What problem does the change try to solve? 
-->


### Objective

<!--
What kind behaviour does it change, add, or remove?
How did it behave before? How does it behave now? 
-->


### Reason

<!--
How did you fix the issue?
Why did you solve it this way? 
-->


### Use case

<!--
How is the change used? maybe share some example code.
Does the change introduce any incompatibility?
-->
