### PR TITLE
fix: WPB-25755 fix for workflows when pulling images and connecting to new VMs

### DIFF
--- a/changelog.d/2-wire-builds/dump-version-info
+++ b/changelog.d/2-wire-builds/dump-version-info
@@ -1,0 +1,1 @@
+Added: Dump version information post creating the artifacts on the stdout

--- a/changelog.d/5-bug-fixes/pipeline-fixes
+++ b/changelog.d/5-bug-fixes/pipeline-fixes
@@ -1,0 +1,1 @@
+Fixed: Update the docker pull logic to retry if initial pull fails and wait when connecting to fresh VMs in hetzner for cd

--- a/nix/scripts/create-container-dump.sh
+++ b/nix/scripts/create-container-dump.sh
@@ -52,13 +52,13 @@ while IFS= read -r image; do
         --retry-times 10 \
         "docker://$image_trimmed" \
         "docker-archive:${tmp_path}" \
-        --additional-tag "$image"
+        --additional-tag "$image" || rc=$?
     else
       skopeo copy --insecure-policy \
         --retry-times 10 \
         "docker://$image_trimmed" \
         "docker-archive:${tmp_path}" \
-        --additional-tag "$image"
+        --additional-tag "$image" || rc=$?
     fi
 
     rc=$?

--- a/nix/scripts/create-container-dump.sh
+++ b/nix/scripts/create-container-dump.sh
@@ -13,34 +13,72 @@ export REGISTRY_TIMEOUT=600 # Registry specific timeout
 
 output_dir=$1
 mkdir -p $1
+
 # Download all the docker images into $1, and append its name to an index.txt
 # If this errors out for you, copy default-policy.json from the skopeo repo to
 # /etc/containers/policy.json
 while IFS= read -r image; do
-    # sanitize the image file name, replace slashes with underscores, suffix with .tar
-    image_filename=$(sed -r "s/[:\/]/_/g" <<< $image)
-    image_path=$(realpath $1)/${image_filename}.tar
-    if [[ -e $image_path ]];then
-      echo "Skipping $image_filename…"
+
+# sanitize the image file name, replace slashes with underscores, suffix with .tar
+  image_filename=$(sed -r "s/[:\/]/_/g" <<< "$image")
+  image_path="$(realpath "$1")/${image_filename}.tar"
+
+  if [[ -s "$image_path" ]]; then
+    echo "Skipping $image_filename…"
+    continue
+  fi
+
+  echo "Fetching $image_filename…"
+
+  # All of these images should be publicly fetchable, especially given we
+  # ship public tarballs containing these images.
+  # ci.sh already honors DOCKER_LOGIN, so do the same here, otherwise
+  # fallback to unauthorized fetching.
+
+  # If an image has both a tag and digest, remove the tag. Return the original if there is no match.
+  image_trimmed=$(echo "$image" | sed -E 's/(.+)(:.+(@.+))/\1\3/')
+
+  tmp_path="${image_path}.tmp"
+  rm -f "$tmp_path"
+
+  success=false
+
+  for attempt in {1..5}; do
+    echo "Attempt $attempt/5 for $image_trimmed"
+
+    if [[ -n "${DOCKER_LOGIN:-}" && "$image" =~ quay.io/wire ]]; then
+      skopeo copy --insecure-policy \
+        --src-creds "$DOCKER_LOGIN" \
+        --retry-times 10 \
+        "docker://$image_trimmed" \
+        "docker-archive:${tmp_path}" \
+        --additional-tag "$image"
     else
-      echo "Fetching $image_filename…"
-
-      # All of these images should be publicly fetchable, especially given we
-      # ship public tarballs containing these images.
-      # ci.sh already honors DOCKER_LOGIN, so do the same here, otherwise
-      # fallback to unauthorized fetching.
-
-      # If an image has both a tag and digest, remove the tag. Return the original if there is no match.
-      image_trimmed=$(echo "$image" | sed -E 's/(.+)(:.+(@.+))/\1\3/')
-      if [[ -n "${DOCKER_LOGIN:-}" && "$image" =~ quay.io/wire ]];then
-        skopeo copy --insecure-policy --src-creds "$DOCKER_LOGIN" --retry-times 10 \
-          docker://$image_trimmed docker-archive:${image_path} --additional-tag $image
-      else
-        skopeo copy --insecure-policy --retry-times 10 \
-          docker://$image_trimmed docker-archive:${image_path} --additional-tag $image
-      fi
-      echo "${image_filename}.tar" >> $(realpath "$1")/index.txt
-      # passing image and $output_dir
-      create-build-entry $image $output_dir
+      skopeo copy --insecure-policy \
+        --retry-times 10 \
+        "docker://$image_trimmed" \
+        "docker-archive:${tmp_path}" \
+        --additional-tag "$image"
     fi
+
+    rc=$?
+
+    if [[ $rc -eq 0 && -s "$tmp_path" ]]; then
+      mv "$tmp_path" "$image_path"
+      success=true
+      break
+    fi
+
+    echo "Fetch failed for $image_trimmed with rc=$rc; retrying…"
+    rm -f "$tmp_path"
+    sleep $((attempt * 20))
+  done
+
+  if [[ "$success" != true ]]; then
+    echo "ERROR: failed to fetch $image after retries" >&2
+    exit 1
+  fi
+
+  echo "${image_filename}.tar" >> "$(realpath "$1")/index.txt"
+  create-build-entry "$image" "$output_dir"
 done

--- a/offline/default-build/build.sh
+++ b/offline/default-build/build.sh
@@ -116,3 +116,16 @@ done
 
 # Create the tar archive with relative paths
 tar czf "$OUTPUT_TAR" "${ITEMS_TO_ARCHIVE[@]}"
+
+# Dumping details of versions for the build and packed
+echo "Dump of versions/helm_image_tree.json"
+cat "${OUTPUT_DIR}/versions/helm_image_tree.json"
+
+echo "Dump of versions/containers_system_images.json"
+cat "${OUTPUT_DIR}/versions/containers_system_images.json"
+
+echo "Dump of versions/wire-binaries.json"
+cat "${OUTPUT_DIR}/versions/wire-binaries.json"
+
+echo "Dump of wire-builds used"
+cat "${OUTPUT_DIR}/build.json"

--- a/offline/demo-build/build.sh
+++ b/offline/demo-build/build.sh
@@ -83,3 +83,10 @@ done
 
 # Create the tar archive with relative paths
 tar czf "$OUTPUT_TAR" "${ITEMS_TO_ARCHIVE[@]}"
+
+# Dumping details of versions for the build and packed
+echo "Dump of versions/helm_image_tree.json"
+cat "${OUTPUT_DIR}/versions/helm_image_tree.json"
+
+echo "Dump of wire-builds used"
+cat "${OUTPUT_DIR}/build.json"

--- a/offline/min-build/build.sh
+++ b/offline/min-build/build.sh
@@ -94,3 +94,10 @@ done
 
 # Create the tar archive with relative paths
 tar czf "$OUTPUT_TAR" "${ITEMS_TO_ARCHIVE[@]}"
+
+# Dumping details of versions for the build and packed
+echo "Dump of versions/helm_image_tree.json"
+cat "${OUTPUT_DIR}/versions/helm_image_tree.json"
+
+echo "Dump of wire-builds used"
+cat "${OUTPUT_DIR}/build.json"

--- a/offline/tasks/proc_pull_charts.sh
+++ b/offline/tasks/proc_pull_charts.sh
@@ -36,13 +36,14 @@ echo "Excluding following charts from the release: $HELM_CHART_EXCLUDE_LIST"
 wire_build_chart_release () {
 
   wire_build="$1"
-  curl "$wire_build" | jq -r --argjson HELM_CHART_EXCLUDE_LIST "$HELM_CHART_EXCLUDE_LIST" '
+  curl "$wire_build" -o "${OUTPUT_DIR}/build.json"
+  jq -r --argjson HELM_CHART_EXCLUDE_LIST "$HELM_CHART_EXCLUDE_LIST" '
   .helmCharts
   | with_entries(select(.key as $k | $HELM_CHART_EXCLUDE_LIST | index($k) | not))
   | to_entries
   | map("\(.key) \(.value.repo) \(.value.version)")
   | join("\n")
-  '
+  ' "${OUTPUT_DIR}/build.json"
 }
 
 # pull_charts() accepts charts in format

--- a/terraform/examples/wiab-staging-hetzner/outputs.tf
+++ b/terraform/examples/wiab-staging-hetzner/outputs.tf
@@ -55,7 +55,7 @@ output "static-inventory" {
         }
       }
       vars = {
-        ansible_ssh_common_args = "-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s -o BatchMode=yes -o ConnectionAttempts=10 -o ServerAliveInterval=60 -o ServerAliveCountMax=3"
+        ansible_ssh_common_args = "-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s -o BatchMode=yes -o ConnectionAttempts=10 -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ConnectTimeout=10"
       }
     }
     private = {
@@ -66,7 +66,7 @@ output "static-inventory" {
         adminhost_local = {}
       }
       vars = {
-        ansible_ssh_common_args = "-o ProxyCommand=\"ssh -i ssh_private_key -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -W %h:%p -q root@${hcloud_server.adminhost.ipv4_address}\" -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s -o BatchMode=yes -o ConnectionAttempts=10 -o ServerAliveInterval=60 -o ServerAliveCountMax=3"
+        ansible_ssh_common_args = "-o ProxyCommand=\"ssh -i ssh_private_key -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -W %h:%p -q root@${hcloud_server.adminhost.ipv4_address}\" -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s -o BatchMode=yes -o ConnectionAttempts=10 -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ConnectTimeout=10"
       }
     }
     adminhost_local = {

--- a/terraform/examples/wiab-staging-hetzner/setup_nodes.yml
+++ b/terraform/examples/wiab-staging-hetzner/setup_nodes.yml
@@ -1,4 +1,20 @@
 ---
+- name: Wait for adminhost private SSH
+  hosts: adminhost
+  gather_facts: no
+  tasks:
+    - name: Wait for SSH on public adminhost
+      wait_for_connection:
+        timeout: 300
+        delay: 5
+
+    - name: Wait until adminhost private IP is reachable from public adminhost
+      wait_for:
+        host: "{{ hostvars['adminhost_local'].ansible_host }}"
+        port: 22
+        timeout: 300
+        delay: 5
+
 - name: Setup adminhost with dnsmasq and Docker
   hosts: adminhost_local
   become: yes


### PR DESCRIPTION
update the docker pull logic to retry if initial pull fails and wait when connecting to fresh VMs in hetzner for cd

<!-- In case this addressed an existing issue 
Fixes ${ISSUE_URL}
-->

### Change type

<!-- choose the kind of change this PR introduces -->

* [x] Fix
* [ ] Feature
* [ ] Documentation
* [ ] Security / Upgrade

### Basic information 

* [ ] THIS CHANGE REQUIRES A DEPLOYMENT PACKAGE RELEASE
* [ ] THIS CHANGE REQUIRES A WIRE-DOCS RELEASE

### Testing

* [x] I ran/applied the changes myself, in a test environment.
* [x] The CI job attached to this repo will test it for me.

#### Offline Build CI (label-based)
Add one or more labels to trigger offline builds:
- `build-default` - Full production build (ansible, terraform, all packages)
- `build-dev` - WIAB/dev build
- `build-wiab-staging` - WIAB-staging build
- `build-min` - Minimal build (fastest, essential charts only)
- `build-all` - Run all three builds

**Note:** No builds run by default. Add a label to trigger CI.

### Tracking

* [x] I added a new entry in an appropriate subdirectory of `changelog.d`
* [x] I mentioned this PR in Jira, OR I mentioned the Jira ticket in this PR.
* [ ] I mentioned this PR in one of the issues attached to one of our repositories.

### Knowledge Transfer
* [ ] An Asciinema session is attached to the Jira ticket.

### Motivation

<!--
What is the motivation for introducing this change?
Which scenario(s) is/are addressed by the change?
What problem does the change try to solve? 
-->


### Objective

<!--
What kind behaviour does it change, add, or remove?
How did it behave before? How does it behave now? 
-->


### Reason

<!--
How did you fix the issue?
Why did you solve it this way? 
-->


### Use case

<!--
How is the change used? maybe share some example code.
Does the change introduce any incompatibility?
-->
