### PR TITLE
Fix ingress-nginx controller image pinning

### DIFF
--- a/changelog.d/3-deploy-builds/fix-ingress-nginx-upstream-image
+++ b/changelog.d/3-deploy-builds/fix-ingress-nginx-upstream-image
@@ -1,0 +1,1 @@
+Changed: stop pinning the ingress-nginx controller image tag in example values so the chart uses the upstream default

--- a/changelog.d/3-deploy-builds/fix-ingress-nginx-upstream-image
+++ b/changelog.d/3-deploy-builds/fix-ingress-nginx-upstream-image
@@ -1,1 +1,1 @@
-Changed: stop pinning the ingress-nginx controller image tag in example values so the chart uses the upstream default
+Changed: stop pinning the ingress-nginx controller and webhook image tags in example values so the chart uses the upstream defaults

--- a/values/ingress-nginx-controller/demo-values.example.yaml
+++ b/values/ingress-nginx-controller/demo-values.example.yaml
@@ -8,7 +8,6 @@ ingress-nginx:
     service:
       type: NodePort
     image:
-      tag: "v1.10.6"
       digest: ""
       digestChroot: ""
     admissionWebhooks:

--- a/values/ingress-nginx-controller/demo-values.example.yaml
+++ b/values/ingress-nginx-controller/demo-values.example.yaml
@@ -13,7 +13,6 @@ ingress-nginx:
     admissionWebhooks:
       patch:
         image:
-          tag: "v20220916-gd32f8c343"
           digest: ""
 
     # Enable prometheus operator to scrape metrics from the ingress-nginx controller with servicemonitor.

--- a/values/ingress-nginx-controller/load-balancer.example.yaml
+++ b/values/ingress-nginx-controller/load-balancer.example.yaml
@@ -9,7 +9,6 @@ ingress-nginx:
     admissionWebhooks:
       patch:
         image:
-          tag: "v20220916-gd32f8c343"
           digest: ""
     # Enable prometheus operator to scrape metrics from the ingress-nginx controller with servicemonitor.
     metrics:

--- a/values/ingress-nginx-controller/load-balancer.example.yaml
+++ b/values/ingress-nginx-controller/load-balancer.example.yaml
@@ -4,7 +4,6 @@
 ingress-nginx:
   controller:
     image:
-      tag: "v1.10.6"
       digest: ""
       digestChroot: ""
     admissionWebhooks:

--- a/values/ingress-nginx-controller/prod-values.example.yaml
+++ b/values/ingress-nginx-controller/prod-values.example.yaml
@@ -8,7 +8,6 @@ ingress-nginx:
     service:
       type: NodePort
     image:
-      tag: "v1.10.6"
       digest: ""
       digestChroot: ""
     admissionWebhooks:

--- a/values/ingress-nginx-controller/prod-values.example.yaml
+++ b/values/ingress-nginx-controller/prod-values.example.yaml
@@ -13,7 +13,6 @@ ingress-nginx:
     admissionWebhooks:
       patch:
         image:
-          tag: "v20220916-gd32f8c343"
           digest: ""
     # Enable prometheus operator to scrape metrics from the ingress-nginx controller with servicemonitor.
     metrics:


### PR DESCRIPTION
## Summary
- Stop pinning the ingress-nginx controller image tag in example values
- Let Helm use the upstream chart default image tag
- Add a changelog entry for the deployment change\n\n## Notes
- Existing unrelated untracked files were left untouched